### PR TITLE
1.0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
 
 
-## [1.0.10] - 2021-05-11
+## [1.0.11] - 2021-05-11
 - Add open_display call before surface::ImageSurface::new.
 - Update FAQ to use 1.0 code . Thanks @sportfloh
+- Add GroupExt::unsafe_clear for faster clearing of group widgets.
 - Update FLTK & cfltk.
 
 ## [1.0.9] - 2021-05-09

--- a/fltk-derive/Cargo.toml
+++ b/fltk-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk-derive"
-version = "1.0.10"
+version = "1.0.11"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 edition = "2018"
 description = "Rust bindings for the FLTK GUI library"

--- a/fltk-derive/src/group.rs
+++ b/fltk-derive/src/group.rs
@@ -59,10 +59,17 @@ pub fn impl_group_trait(ast: &DeriveInput) -> TokenStream {
             }
 
             fn clear(&mut self) {
+                assert!(!self.was_deleted());
                 unsafe {
-                    assert!(!self.was_deleted());
-                    #clear(self.inner);
+                    for c in self.children()..0 {
+                        crate::widget::Widget::delete(crate::widget::Widget::from_widget_ptr(self.child(c).unwrap().as_widget_ptr()));
+                    }
                 }
+            }
+
+            unsafe fn unsafe_clear(&mut self) {
+                assert!(!self.was_deleted());
+                unsafe { #clear(self.inner); }
             }
 
             fn children(&self) -> i32 {

--- a/fltk-derive/src/widget.rs
+++ b/fltk-derive/src/widget.rs
@@ -353,7 +353,7 @@ pub fn impl_widget_trait(ast: &DeriveInput) -> TokenStream {
 
         impl Clone for #name {
             fn clone(&self) -> #name {
-                assert!(!self.was_deleted());
+                assert!(!self.was_deleted());                
                 #name { inner: self.inner, tracker: self.tracker }
             }
         }
@@ -721,11 +721,7 @@ pub fn impl_widget_trait(ast: &DeriveInput) -> TokenStream {
 
             fn was_deleted(&self) -> bool {
                 unsafe {
-                    if self.inner.is_null() || self.tracker.is_null() {
-                        return true;
-                    } else {
-                        return fltk_sys::fl::Fl_Widget_Tracker_deleted(self.tracker) != 0;
-                    }
+                    self.inner.is_null() || self.tracker.is_null() || fltk_sys::fl::Fl_Widget_Tracker_deleted(self.tracker) != 0
                 }
             }
 

--- a/fltk/Cargo.toml
+++ b/fltk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk"
-version = "1.0.10"
+version = "1.0.11"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 edition = "2018"
 description = "Rust bindings for the FLTK GUI library"
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 
 [dependencies]
 fltk-sys = { path = "../fltk-sys", version = "=1.0.10" }
-fltk-derive = { path = "../fltk-derive", version = "=1.0.10" }
+fltk-derive = { path = "../fltk-derive", version = "=1.0.11" }
 lazy_static = "^1.4.0"
 bitflags = "^1.2.1"
 gl_loader = { version = "^0.1.2", optional = true }

--- a/fltk/src/prelude.rs
+++ b/fltk/src/prelude.rs
@@ -404,6 +404,10 @@ pub unsafe trait GroupExt: WidgetExt {
     fn end(&self);
     /// Clear a group from all widgets
     fn clear(&mut self);
+    /// Clear a group from all widgets using FLTK's clear call.
+    /// # Safety
+    /// Ignores widget tracking
+    unsafe fn unsafe_clear(&mut self);
     /// Return the number of children in a group
     fn children(&self) -> i32;
     /// Return child widget by index


### PR DESCRIPTION
- Add open_display call before surface::ImageSurface::new.
- Update FAQ to use 1.0 code . Thanks @sportfloh
- Add GroupExt::unsafe_clear for faster clearing of group widgets.
- Update FLTK & cfltk.