### PR TITLE
1.0.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 
 
-## [1.0.12] - Unreleased
+## [1.0.12] - 2021-05-11
 - Pass FileChooser title as long-lived string.
+- Fix GroupExt::clear to account for empty groups.
 
 ## [1.0.11] - 2021-05-11
 - Add open_display call before surface::ImageSurface::new.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 
+## [1.0.12] - Unreleased
+- Pass FileChooser title as long-lived string.
+
 ## [1.0.11] - 2021-05-11
 - Add open_display call before surface::ImageSurface::new.
 - Update FAQ to use 1.0 code . Thanks @sportfloh

--- a/fltk-derive/Cargo.toml
+++ b/fltk-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk-derive"
-version = "1.0.11"
+version = "1.0.12"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 edition = "2018"
 description = "Rust bindings for the FLTK GUI library"

--- a/fltk-derive/src/group.rs
+++ b/fltk-derive/src/group.rs
@@ -61,8 +61,10 @@ pub fn impl_group_trait(ast: &DeriveInput) -> TokenStream {
             fn clear(&mut self) {
                 assert!(!self.was_deleted());
                 unsafe {
-                    for c in self.children()..0 {
-                        crate::widget::Widget::delete(crate::widget::Widget::from_widget_ptr(self.child(c).unwrap().as_widget_ptr()));
+                    for c in 0..self.children() {
+                        crate::widget::Widget::delete(
+                            crate::widget::Widget::from_widget_ptr(self.child(c).unwrap().as_widget_ptr())
+                        );
                     }
                 }
             }

--- a/fltk/Cargo.toml
+++ b/fltk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk"
-version = "1.0.11"
+version = "1.0.12"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 edition = "2018"
 description = "Rust bindings for the FLTK GUI library"
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 
 [dependencies]
 fltk-sys = { path = "../fltk-sys", version = "=1.0.11" }
-fltk-derive = { path = "../fltk-derive", version = "=1.0.11" }
+fltk-derive = { path = "../fltk-derive", version = "=1.0.12" }
 lazy_static = "^1.4.0"
 bitflags = "^1.2.1"
 gl_loader = { version = "^0.1.2", optional = true }

--- a/fltk/src/dialog.rs
+++ b/fltk/src/dialog.rs
@@ -584,7 +584,7 @@ impl FileChooser {
                 dir.as_ptr(),
                 pattern.as_ptr(),
                 typ.bits as i32,
-                title.as_ptr(),
+                title.into_raw(),
             );
             assert!(!ptr.is_null());
             FileChooser { inner: ptr }


### PR DESCRIPTION
- Pass FileChooser title as long-lived string.
- Fix GroupExt::clear to account for empty groups.