### PR TITLE
1.0.17

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,3 @@
+# Description
+
+Please include a summary of the change and whether it fixes an issue/bug. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add enums::FrameType::swap_frames() to swap frame types.
 - Free WindowExt::raw_handle() memory on error.
 - Use full font name instead of family name when handling external truetype fonts.
+- Add convenience functions to enums::Font for loading and replacing fonts.
 
 ## [1.0.16] - 2021-06-02
 - Update to latest FLTK with gdi+ support on Windows (for anti-aliased oblique lines and curves).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 ## [1.0.17] - Unreleased
 - Update app::set_callback to reflect WidgetExt::set_callback.
+- Add app::swap_frame_type() to swap the default frame type with a new one.
+- Add app::frame_type() to get the default frame type.
+- Add enums::FrameType::swap_frames() to swap frame types.
 
 ## [1.0.16] - 2021-06-02
 - Update to latest FLTK with gdi+ support on Windows (for anti-aliased oblique lines and curves).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,13 @@
 # Changelog
 
 
-## [1.0.17] - Unreleased
+## [1.0.17] - 2021-06-07
 - Update app::set_callback to reflect WidgetExt::set_callback.
 - Add app::swap_frame_type() to swap the default frame type with a new one.
 - Add app::frame_type() to get the default frame type.
 - Add enums::FrameType::swap_frames() to swap frame types.
+- Free WindowExt::raw_handle() memory on error.
+- Use full font name instead of family name when handling external truetype fonts.
 
 ## [1.0.16] - 2021-06-02
 - Update to latest FLTK with gdi+ support on Windows (for anti-aliased oblique lines and curves).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 
+## [1.0.17] - Unreleased
+- Update app::set_callback to reflect WidgetExt::set_callback.
+
 ## [1.0.16] - 2021-06-02
 - Update to latest FLTK with gdi+ support on Windows (for anti-aliased oblique lines and curves).
 - Fix GroupExt::clear().

--- a/fltk-derive/Cargo.toml
+++ b/fltk-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk-derive"
-version = "1.0.16"
+version = "1.0.17"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 edition = "2018"
 description = "Rust bindings for the FLTK GUI library"

--- a/fltk-sys/Cargo.toml
+++ b/fltk-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk-sys"
-version = "1.0.16"
+version = "1.0.17"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 build = "build/main.rs"
 edition = "2018"

--- a/fltk-sys/build/android.rs
+++ b/fltk-sys/build/android.rs
@@ -5,6 +5,9 @@ use std::{
 };
 
 pub fn build(out_dir: &Path, target_triple: &str) {
+    println!("cargo:rerun-if-env-changed=ANDROID_SDK_ROOT");
+    println!("cargo:rerun-if-env-changed=ANDROID_NDK_ROOT");
+    
     let sdk =
         PathBuf::from(env::var("ANDROID_SDK_ROOT").expect("ANDROID_SDK_ROOT needs to be set!"));
     let mut ndk: Option<PathBuf> = None;

--- a/fltk-sys/src/fl.rs
+++ b/fltk-sys/src/fl.rs
@@ -129,6 +129,9 @@ extern "C" {
     pub fn Fl_set_font(arg1: libc::c_int, arg2: libc::c_int);
 }
 extern "C" {
+    pub fn Fl_set_font2(arg1: libc::c_int, arg2: *const libc::c_char);
+}
+extern "C" {
     pub fn Fl_set_font_size(arg1: libc::c_int);
 }
 extern "C" {

--- a/fltk/Cargo.toml
+++ b/fltk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk"
-version = "1.0.16"
+version = "1.0.17"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 edition = "2018"
 description = "Rust bindings for the FLTK GUI library"

--- a/fltk/Cargo.toml
+++ b/fltk/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 
 [dependencies]
 fltk-sys = { path = "../fltk-sys", version = "=1.0.17" }
-fltk-derive = { path = "../fltk-derive", version = "=1.0.16" }
+fltk-derive = { path = "../fltk-derive", version = "=1.0.17" }
 lazy_static = "^1.4.0"
 bitflags = "^1.2.1"
 gl_loader = { version = "^0.1.2", optional = true }

--- a/fltk/Cargo.toml
+++ b/fltk/Cargo.toml
@@ -17,7 +17,7 @@ name = "fltk"
 path = "src/lib.rs"
 
 [dependencies]
-fltk-sys = { path = "../fltk-sys", version = "=1.0.16" }
+fltk-sys = { path = "../fltk-sys", version = "=1.0.17" }
 fltk-derive = { path = "../fltk-derive", version = "=1.0.16" }
 lazy_static = "^1.4.0"
 bitflags = "^1.2.1"

--- a/fltk/src/app.rs
+++ b/fltk/src/app.rs
@@ -514,6 +514,22 @@ pub fn set_frame_type(new_frame: FrameType) {
     unsafe {
         let new_frame = new_frame as i32;
         let mut curr = CURRENT_FRAME.lock().unwrap();
+        fl::Fl_set_box_type(*curr, new_frame);
+        *curr = new_frame;
+    }
+}
+
+/// Get the app's frame type
+pub fn frame_type() -> FrameType {
+    let curr = CURRENT_FRAME.lock().unwrap();
+    FrameType::by_index(*curr as _)
+}
+
+/// Swap the default frame type with a new frame type
+pub fn swap_frame_type(new_frame: FrameType) {
+    unsafe {
+        let new_frame = new_frame as i32;
+        let mut curr = CURRENT_FRAME.lock().unwrap();
         fl::Fl_set_box_type(56, *curr);
         fl::Fl_set_box_type(*curr, new_frame);
         fl::Fl_set_box_type(new_frame, 56);

--- a/fltk/src/app.rs
+++ b/fltk/src/app.rs
@@ -182,7 +182,7 @@ impl App {
         self
     }
 
-    /**!
+    /**
         Loads a font from a path.
         On success, returns a String with the ttf Font Family name. The font's index is always 16.
         As such only one font can be loaded at a time.
@@ -459,7 +459,8 @@ where
     }
 }
 
-/**!
+#[allow(clippy::missing_safety_doc)]
+/**
     Set a widget callback using a C style API
     ```rust,no_run
     use fltk::{prelude::*, *};
@@ -482,9 +483,9 @@ where
         app::set_raw_callback(&mut but, frame.as_widget_ptr() as *mut _, Some(|_ , _| { println!("Also works!")}));
     }
     ```
+    # Safety
+    The function involves dereferencing externally provided raw pointers
 */
-/// # Safety
-/// The function involves dereferencing externally provided raw pointers
 pub unsafe fn set_raw_callback<W>(
     widget: &mut W,
     data: *mut raw::c_void,
@@ -705,15 +706,16 @@ pub unsafe fn awake_msg<T>(msg: T) {
     fl::Fl_awake_msg(Box::into_raw(Box::from(msg)) as *mut raw::c_void);
 }
 
-/**!
+#[allow(clippy::missing_safety_doc)]
+/**
     Receives a custom message
     ```rust,no_run
     use fltk::{prelude::*, *};
     if let Some(msg) = unsafe { app::thread_msg::<i32>() } { /* do something */ }
     ```
+    # Safety
+    The type must correspond to the received message
 */
-/// # Safety
-/// The type must correspond to the received message
 pub unsafe fn thread_msg<T>() -> Option<T> {
     let msg = fl::Fl_thread_msg();
     if msg.is_null() {
@@ -836,7 +838,7 @@ pub fn quit() {
     }
 }
 
-/**!
+/**
     Adds a one-shot timeout callback. The timeout duration `tm` is indicated in seconds
     Example:
     ```rust,no_run
@@ -868,7 +870,7 @@ pub fn add_timeout<F: FnMut() + 'static>(tm: f64, cb: F) {
     }
 }
 
-/**!
+/**
     Repeats a timeout callback from the expiration of the previous timeout.
     You may only call this method inside a timeout callback.
     The timeout duration `tm` is indicated in seconds
@@ -957,7 +959,7 @@ pub fn event_inside(x: i32, y: i32, w: i32, h: i32) -> bool {
     unsafe { fl::Fl_event_inside(x, y, w, h) != 0 }
 }
 
-/**!
+/**
     Gets the widget that is below the mouse cursor.
     This returns an Option<impl WidgetExt> which can be specified in the function call
     ```rust,no_run
@@ -1248,7 +1250,7 @@ pub fn get_system_colors() {
     unsafe { fl::Fl_get_system_colors() }
 }
 
-/**!
+/**
     Send a signal to a window.
     Integral values from 0 to 30 are reserved.
     Returns Ok(true) if the event was handled.
@@ -1288,7 +1290,7 @@ pub fn handle<I: Into<i32> + Copy + PartialEq + PartialOrd, W: WindowExt>(
     }
 }
 
-/**!
+/**
     Send a signal to a window.
     Integral values from 0 to 30 are reserved.
     Returns Ok(true) if the event was handled.

--- a/fltk/src/app.rs
+++ b/fltk/src/app.rs
@@ -182,20 +182,22 @@ impl App {
         self
     }
 
-    /// Loads a font from a path.
-    /// On success, returns a String with the ttf Font Family name. The font's index is always 16.
-    /// As such only one font can be loaded at a time.
-    /// The font name can be used with `Font::by_name`, and index with `Font::by_index`.
-    /// # Examples
-    /// ```rust,no_run
-    /// use fltk::{prelude::*, *};
-    /// let app = app::App::default();
-    /// let font = app.load_font("font.ttf").unwrap();
-    /// let mut frame = frame::Frame::new(0, 0, 400, 100, "Hello");
-    /// frame.set_label_font(enums::Font::by_name(&font));
-    /// ```
-    /// # Errors
-    /// Returns `ResourceNotFound` if the Font file was not found
+    /**!
+        Loads a font from a path.
+        On success, returns a String with the ttf Font Family name. The font's index is always 16.
+        As such only one font can be loaded at a time.
+        The font name can be used with `Font::by_name`, and index with `Font::by_index`.
+        # Examples
+        ```rust,no_run
+        use fltk::{prelude::*, *};
+        let app = app::App::default();
+        let font = app.load_font("font.ttf").unwrap();
+        let mut frame = frame::Frame::new(0, 0, 400, 100, "Hello");
+        frame.set_label_font(enums::Font::by_name(&font));
+        ```
+        # Errors
+        Returns `ResourceNotFound` if the Font file was not found
+    */
     pub fn load_font<P: AsRef<path::Path>>(self, path: P) -> Result<String, FltkError> {
         Self::load_font_(path.as_ref())
     }
@@ -415,19 +417,12 @@ pub fn event_state() -> Shortcut {
 
 /// Returns a pair of the width and height of the screen
 pub fn screen_size() -> (f64, f64) {
-    unsafe {
-        (
-            (fl::Fl_screen_w() as f64),
-            (fl::Fl_screen_h() as f64),
-        )
-    }
+    unsafe { ((fl::Fl_screen_w() as f64), (fl::Fl_screen_h() as f64)) }
 }
 
 /// Returns a pair of the x & y coords of the screen
 pub fn screen_coords() -> (i32, i32) {
-    unsafe {
-        (fl::Fl_screen_x(), fl::Fl_screen_y())
-    }
+    unsafe { (fl::Fl_screen_x(), fl::Fl_screen_y()) }
 }
 
 /// Used for widgets implementing the `InputExt`, pastes content from the clipboard
@@ -450,7 +445,8 @@ where
     assert!(!widget.was_deleted());
     unsafe {
         unsafe extern "C" fn shim(wid: *mut fltk_sys::widget::Fl_Widget, data: *mut raw::c_void) {
-            let a: *mut Box<dyn FnMut(&mut dyn WidgetExt)> = data as *mut Box<dyn FnMut(&mut dyn WidgetExt)>;
+            let a: *mut Box<dyn FnMut(&mut dyn WidgetExt)> =
+                data as *mut Box<dyn FnMut(&mut dyn WidgetExt)>;
             let f: &mut (dyn FnMut(&mut dyn WidgetExt)) = &mut **a;
             let mut wid = crate::widget::Widget::from_widget_ptr(wid);
             let _ = panic::catch_unwind(panic::AssertUnwindSafe(|| f(&mut wid)));
@@ -463,28 +459,30 @@ where
     }
 }
 
-/// Set a widget callback using a C style API
-/// ```rust,no_run
-/// use fltk::{prelude::*, *};
-/// use std::os::raw::*;
-/// // data can be anything, even a different widget
-/// fn cb(w: app::WidgetPtr, data: *mut c_void) {
-///     // To access the button
-///     let mut btn = unsafe { button::Button::from_widget_ptr(w) }; // Gets a Widget
-///     btn.set_label("Works!");
-///     // To access the frame
-///     let mut frm = unsafe { widget::Widget::from_widget_ptr(data as app::WidgetPtr) };
-///     frm.set_label("Works!");
-/// }
-/// let mut but = button::Button::default();
-/// let mut frame = frame::Frame::default();
-/// unsafe {
-///     // If no data needs to be passed, you can pass 0 as *mut _
-///     app::set_raw_callback(&mut but, frame.as_widget_ptr() as *mut _, Some(cb));
-///     // Using a closure also works
-///     app::set_raw_callback(&mut but, frame.as_widget_ptr() as *mut _, Some(|_ , _| { println!("Also works!")}));
-/// }
-/// ```
+/**!
+    Set a widget callback using a C style API
+    ```rust,no_run
+    use fltk::{prelude::*, *};
+    use std::os::raw::*;
+    // data can be anything, even a different widget
+    fn cb(w: app::WidgetPtr, data: *mut c_void) {
+        // To access the button
+        let mut btn = unsafe { button::Button::from_widget_ptr(w) }; // Gets a Widget
+        btn.set_label("Works!");
+        // To access the frame
+        let mut frm = unsafe { widget::Widget::from_widget_ptr(data as app::WidgetPtr) };
+        frm.set_label("Works!");
+    }
+    let mut but = button::Button::default();
+    let mut frame = frame::Frame::default();
+    unsafe {
+        // If no data needs to be passed, you can pass 0 as *mut _
+        app::set_raw_callback(&mut but, frame.as_widget_ptr() as *mut _, Some(cb));
+        // Using a closure also works
+        app::set_raw_callback(&mut but, frame.as_widget_ptr() as *mut _, Some(|_ , _| { println!("Also works!")}));
+    }
+    ```
+*/
 /// # Safety
 /// The function involves dereferencing externally provided raw pointers
 pub unsafe fn set_raw_callback<W>(
@@ -707,11 +705,13 @@ pub unsafe fn awake_msg<T>(msg: T) {
     fl::Fl_awake_msg(Box::into_raw(Box::from(msg)) as *mut raw::c_void);
 }
 
-/// Receives a custom message
-/// ```rust,no_run
-/// use fltk::{prelude::*, *};
-/// if let Some(msg) = unsafe { app::thread_msg::<i32>() } { /* do something */ }
-/// ```
+/**!
+    Receives a custom message
+    ```rust,no_run
+    use fltk::{prelude::*, *};
+    if let Some(msg) = unsafe { app::thread_msg::<i32>() } { /* do something */ }
+    ```
+*/
 /// # Safety
 /// The type must correspond to the received message
 pub unsafe fn thread_msg<T>() -> Option<T> {
@@ -836,22 +836,24 @@ pub fn quit() {
     }
 }
 
-/// Adds a one-shot timeout callback. The timeout duration `tm` is indicated in seconds
-/// Example:
-/// ```rust,no_run
-/// use fltk::{prelude::*, *};
-/// fn callback() {
-///     println!("TICK");
-///     app::repeat_timeout(1.0, callback);
-/// }
-/// fn main() {
-///     let app = app::App::default();
-///     let mut wind = window::Window::new(100, 100, 400, 300, "");
-///     wind.show();
-///     app::add_timeout(1.0, callback);
-///     app.run().unwrap();
-/// }
-/// ```
+/**!
+    Adds a one-shot timeout callback. The timeout duration `tm` is indicated in seconds
+    Example:
+    ```rust,no_run
+    use fltk::{prelude::*, *};
+    fn callback() {
+        println!("TICK");
+        app::repeat_timeout(1.0, callback);
+    }
+    fn main() {
+        let app = app::App::default();
+        let mut wind = window::Window::new(100, 100, 400, 300, "");
+        wind.show();
+        app::add_timeout(1.0, callback);
+        app.run().unwrap();
+    }
+    ```
+*/
 pub fn add_timeout<F: FnMut() + 'static>(tm: f64, cb: F) {
     unsafe {
         unsafe extern "C" fn shim(data: *mut raw::c_void) {
@@ -866,24 +868,26 @@ pub fn add_timeout<F: FnMut() + 'static>(tm: f64, cb: F) {
     }
 }
 
-/// Repeats a timeout callback from the expiration of the previous timeout.
-/// You may only call this method inside a timeout callback.
-/// The timeout duration `tm` is indicated in seconds
-/// Example:
-/// ```rust,no_run
-/// use fltk::{prelude::*, *};
-/// fn callback() {
-///     println!("TICK");
-///     app::repeat_timeout(1.0, callback);
-/// }
-/// fn main() {
-///     let app = app::App::default();
-///     let mut wind = window::Window::new(100, 100, 400, 300, "");
-///     wind.show();
-///     app::add_timeout(1.0, callback);
-///     app.run().unwrap();
-/// }
-/// ```
+/**!
+    Repeats a timeout callback from the expiration of the previous timeout.
+    You may only call this method inside a timeout callback.
+    The timeout duration `tm` is indicated in seconds
+    Example:
+    ```rust,no_run
+    use fltk::{prelude::*, *};
+    fn callback() {
+        println!("TICK");
+        app::repeat_timeout(1.0, callback);
+    }
+    fn main() {
+        let app = app::App::default();
+        let mut wind = window::Window::new(100, 100, 400, 300, "");
+        wind.show();
+        app::add_timeout(1.0, callback);
+        app.run().unwrap();
+    }
+    ```
+*/
 pub fn repeat_timeout<F: FnMut() + 'static>(tm: f64, cb: F) {
     unsafe {
         unsafe extern "C" fn shim(data: *mut raw::c_void) {
@@ -953,13 +957,15 @@ pub fn event_inside(x: i32, y: i32, w: i32, h: i32) -> bool {
     unsafe { fl::Fl_event_inside(x, y, w, h) != 0 }
 }
 
-/// Gets the widget that is below the mouse cursor.
-/// This returns an Option<impl WidgetExt> which can be specified in the function call
-/// ```rust,no_run
-/// use fltk::app;
-/// use fltk::widget;
-/// let w = app::belowmouse::<widget::Widget>(); // or by specifying a more concrete type
-/// ```
+/**!
+    Gets the widget that is below the mouse cursor.
+    This returns an Option<impl WidgetExt> which can be specified in the function call
+    ```rust,no_run
+    use fltk::app;
+    use fltk::widget;
+    let w = app::belowmouse::<widget::Widget>(); // or by specifying a more concrete type
+    ```
+*/
 pub fn belowmouse<Wid: WidgetExt>() -> Option<impl WidgetExt> {
     unsafe {
         let x = fl::Fl_belowmouse() as *mut fltk_sys::fl::Fl_Widget;
@@ -1242,31 +1248,33 @@ pub fn get_system_colors() {
     unsafe { fl::Fl_get_system_colors() }
 }
 
-/// Send a signal to a window.
-/// Integral values from 0 to 30 are reserved.
-/// Returns Ok(true) if the event was handled.
-/// Returns Ok(false) if the event was not handled.
-/// Returns Err on error or in use of one of the reserved values.
-/// ```rust,no_run
-/// use fltk::{prelude::*, *};
-/// const CHANGE_FRAME: i32 = 100;
-/// let mut wind = window::Window::default();
-/// let mut but = button::Button::default();
-/// let mut frame = frame::Frame::default();
-/// but.set_callback(move |_| {
-///     let _ = app::handle(CHANGE_FRAME, &wind).unwrap();
-/// });
-/// frame.handle(move |f, ev| {
-///     if ev == CHANGE_FRAME.into() {
-///         f.set_label("Hello world");
-///         true
-///     } else {
-///         false
-///     }
-/// });
-/// ```
-/// # Errors
-/// Returns Err on error or in use of one of the reserved values.
+/**!
+    Send a signal to a window.
+    Integral values from 0 to 30 are reserved.
+    Returns Ok(true) if the event was handled.
+    Returns Ok(false) if the event was not handled.
+    Returns Err on error or in use of one of the reserved values.
+    ```rust,no_run
+    use fltk::{prelude::*, *};
+    const CHANGE_FRAME: i32 = 100;
+    let mut wind = window::Window::default();
+    let mut but = button::Button::default();
+    let mut frame = frame::Frame::default();
+    but.set_callback(move |_| {
+        let _ = app::handle(CHANGE_FRAME, &wind).unwrap();
+    });
+    frame.handle(move |f, ev| {
+        if ev == CHANGE_FRAME.into() {
+            f.set_label("Hello world");
+            true
+        } else {
+            false
+        }
+    });
+    ```
+    # Errors
+    Returns Err on error or in use of one of the reserved values.
+*/
 pub fn handle<I: Into<i32> + Copy + PartialEq + PartialOrd, W: WindowExt>(
     msg: I,
     w: &W,
@@ -1280,30 +1288,32 @@ pub fn handle<I: Into<i32> + Copy + PartialEq + PartialOrd, W: WindowExt>(
     }
 }
 
-/// Send a signal to a window.
-/// Integral values from 0 to 30 are reserved.
-/// Returns Ok(true) if the event was handled.
-/// Returns Ok(false) if the event was not handled.
-/// ```rust,no_run
-/// use fltk::{prelude::*, *};
-/// const CHANGE_FRAME: i32 = 100;
-/// let mut wind = window::Window::default();
-/// let mut but = button::Button::default();
-/// let mut frame = frame::Frame::default();
-/// but.set_callback(move |_| {
-///     let _ = app::handle_main(CHANGE_FRAME).unwrap();
-/// });
-/// frame.handle(move |f, ev| {
-///     if ev == CHANGE_FRAME.into() {
-///         f.set_label("Hello world");
-///         true
-///     } else {
-///         false
-///     }
-/// });
-/// ```
-/// # Errors
-/// Returns Err on error or in use of one of the reserved values.
+/**!
+    Send a signal to a window.
+    Integral values from 0 to 30 are reserved.
+    Returns Ok(true) if the event was handled.
+    Returns Ok(false) if the event was not handled.
+    ```rust,no_run
+    use fltk::{prelude::*, *};
+    const CHANGE_FRAME: i32 = 100;
+    let mut wind = window::Window::default();
+    let mut but = button::Button::default();
+    let mut frame = frame::Frame::default();
+    but.set_callback(move |_| {
+        let _ = app::handle_main(CHANGE_FRAME).unwrap();
+    });
+    frame.handle(move |f, ev| {
+        if ev == CHANGE_FRAME.into() {
+            f.set_label("Hello world");
+            true
+        } else {
+            false
+        }
+    });
+    ```
+    # Errors
+    Returns Err on error or in use of one of the reserved values.
+*/
 pub fn handle_main<I: Into<i32> + Copy + PartialEq + PartialOrd>(
     msg: I,
 ) -> Result<bool, FltkError> {
@@ -1348,9 +1358,7 @@ pub fn screen_count() -> i32 {
 
 /// Get the screen number based on its coordinates
 pub fn screen_num(x: i32, y: i32) -> i32 {
-    unsafe {
-        fl::Fl_screen_num(x, y)
-    }
+    unsafe { fl::Fl_screen_num(x, y) }
 }
 
 /// Get a screen's dpi resolution

--- a/fltk/src/browser.rs
+++ b/fltk/src/browser.rs
@@ -9,7 +9,7 @@ use std::{
     os::raw,
 };
 
-/**!
+/**
     Creates a normal browser.
     Example usage:
     ```rust,no_run

--- a/fltk/src/browser.rs
+++ b/fltk/src/browser.rs
@@ -9,23 +9,25 @@ use std::{
     os::raw,
 };
 
-/// Creates a normal browser.
-/// Example usage:
-/// ```rust,no_run
-/// use fltk::{prelude::*, *};
-/// let mut b = browser::Browser::new(10, 10, 900 - 20, 300 - 20, "");
-/// let widths = &[50, 50, 50, 70, 70, 40, 40, 70, 70, 50];
-/// b.set_column_widths(widths);
-/// b.set_column_char('\t');
-/// b.add("USER\tPID\t%CPU\t%MEM\tVSZ\tRSS\tTTY\tSTAT\tSTART\tTIME\tCOMMAND");
-/// b.add("root\t2888\t0.0\t0.0\t1352\t0\ttty3\tSW\tAug15\t0:00\t@b@f/sbin/mingetty tty3");
-/// b.add("erco\t2889\t0.0\t13.0\t221352\t0\ttty3\tR\tAug15\t1:34\t@b@f/usr/local/bin/render a35 0004");
-/// b.add("uucp\t2892\t0.0\t0.0\t1352\t0\tttyS0\tSW\tAug15\t0:00\t@b@f/sbin/agetty -h 19200 ttyS0 vt100");
-/// b.add("root\t13115\t0.0\t0.0\t1352\t0\ttty2\tSW\tAug30\t0:00\t@b@f/sbin/mingetty tty2");
-/// b.add(
-///     "root\t13464\t0.0\t0.0\t1352\t0\ttty1\tSW\tAug30\t0:00\t@b@f/sbin/mingetty tty1 --noclear",
-/// );
-/// ```
+/**!
+    Creates a normal browser.
+    Example usage:
+    ```rust,no_run
+    use fltk::{prelude::*, *};
+    let mut b = browser::Browser::new(10, 10, 900 - 20, 300 - 20, "");
+    let widths = &[50, 50, 50, 70, 70, 40, 40, 70, 70, 50];
+    b.set_column_widths(widths);
+    b.set_column_char('\t');
+    b.add("USER\tPID\t%CPU\t%MEM\tVSZ\tRSS\tTTY\tSTAT\tSTART\tTIME\tCOMMAND");
+    b.add("root\t2888\t0.0\t0.0\t1352\t0\ttty3\tSW\tAug15\t0:00\t@b@f/sbin/mingetty tty3");
+    b.add("erco\t2889\t0.0\t13.0\t221352\t0\ttty3\tR\tAug15\t1:34\t@b@f/usr/local/bin/render a35 0004");
+    b.add("uucp\t2892\t0.0\t0.0\t1352\t0\tttyS0\tSW\tAug15\t0:00\t@b@f/sbin/agetty -h 19200 ttyS0 vt100");
+    b.add("root\t13115\t0.0\t0.0\t1352\t0\ttty2\tSW\tAug30\t0:00\t@b@f/sbin/mingetty tty2");
+    b.add(
+        "root\t13464\t0.0\t0.0\t1352\t0\ttty1\tSW\tAug30\t0:00\t@b@f/sbin/mingetty tty1 --noclear",
+    );
+    ```
+*/
 #[derive(WidgetBase, WidgetExt, BrowserExt, Debug)]
 pub struct Browser {
     inner: *mut Fl_Browser,

--- a/fltk/src/dialog.rs
+++ b/fltk/src/dialog.rs
@@ -520,41 +520,43 @@ pub fn beep(tp: BeepType) {
     unsafe { Fl_beep(tp as i32) }
 }
 
-/// FLTK's own `FileChooser`. Which differs for the Native `FileDialog`
-/// Example:
-/// ```rust,no_run
-/// use fltk::{prelude::*, *};
-/// let mut chooser = dialog::FileChooser::new(
-///     ".",                    // directory
-///     "*",                    // filter or pattern
-///     dialog::FileChooserType::Multi, // chooser type
-///     "Title Of Chooser",     // title
-/// );
-/// chooser.show();
-/// chooser.window().set_pos(300, 300);
-/// // Block until user picks something.
-/// //     (The other way to do this is to use a callback())
-/// //
-/// while chooser.shown() {
-///     app::wait();
-/// }
-/// // User hit cancel?
-/// if chooser.value(1).is_none() {
-///     println!("(User hit 'Cancel')");
-///     return;
-/// }
-/// // Print what the user picked
-/// println!("--------------------");
-/// println!("DIRECTORY: '{}'", chooser.directory().unwrap());
-/// println!("    VALUE: '{}'", chooser.value(1).unwrap()); // value starts at 1!
-/// println!("    COUNT: {} files selected", chooser.count());
-/// // Multiple files? Show all of them
-/// if chooser.count() > 1 {
-///     for t in 1..=chooser.count() {
-///         println!(" VALUE[{}]: '{}'", t, chooser.value(t).unwrap());
-///     }
-/// }
-/// ```
+/**!
+    FLTK's own `FileChooser`. Which differs for the Native `FileDialog`
+    Example:
+    ```rust,no_run
+    use fltk::{prelude::*, *};
+    let mut chooser = dialog::FileChooser::new(
+        ".",                    // directory
+        "*",                    // filter or pattern
+        dialog::FileChooserType::Multi, // chooser type
+        "Title Of Chooser",     // title
+    );
+    chooser.show();
+    chooser.window().set_pos(300, 300);
+    // Block until user picks something.
+    //     (The other way to do this is to use a callback())
+    //
+    while chooser.shown() {
+        app::wait();
+    }
+    // User hit cancel?
+    if chooser.value(1).is_none() {
+        println!("(User hit 'Cancel')");
+        return;
+    }
+    // Print what the user picked
+    println!("--------------------");
+    println!("DIRECTORY: '{}'", chooser.directory().unwrap());
+    println!("    VALUE: '{}'", chooser.value(1).unwrap()); // value starts at 1!
+    println!("    COUNT: {} files selected", chooser.count());
+    // Multiple files? Show all of them
+    if chooser.count() > 1 {
+        for t in 1..=chooser.count() {
+            println!(" VALUE[{}]: '{}'", t, chooser.value(t).unwrap());
+        }
+    }
+    ```
+*/
 pub struct FileChooser {
     inner: *mut Fl_File_Chooser,
 }
@@ -1067,13 +1069,15 @@ pub fn dir_chooser(message: &str, fname: &str, relative: bool) -> Option<String>
     }
 }
 
-/// Shows a file chooser returning a String.
-/// Example:
-/// ```rust,no_run
-/// use fltk::{prelude::*, *};
-/// let file = dialog::file_chooser("Choose File", "*.rs", ".", true).unwrap();
-/// println!("{}", file);
-/// ```
+/**!
+    Shows a file chooser returning a String.
+    Example:
+    ```rust,no_run
+    use fltk::{prelude::*, *};
+    let file = dialog::file_chooser("Choose File", "*.rs", ".", true).unwrap();
+    println!("{}", file);
+    ```
+*/
 pub fn file_chooser(message: &str, pattern: &str, dir: &str, relative: bool) -> Option<String> {
     let message = CString::safe_new(message);
     let pattern = CString::safe_new(pattern);

--- a/fltk/src/dialog.rs
+++ b/fltk/src/dialog.rs
@@ -520,7 +520,7 @@ pub fn beep(tp: BeepType) {
     unsafe { Fl_beep(tp as i32) }
 }
 
-/**!
+/**
     FLTK's own `FileChooser`. Which differs for the Native `FileDialog`
     Example:
     ```rust,no_run
@@ -1069,7 +1069,7 @@ pub fn dir_chooser(message: &str, fname: &str, relative: bool) -> Option<String>
     }
 }
 
-/**!
+/**
     Shows a file chooser returning a String.
     Example:
     ```rust,no_run

--- a/fltk/src/draw.rs
+++ b/fltk/src/draw.rs
@@ -682,15 +682,17 @@ pub fn reset_spot() {
     unsafe { Fl_reset_spot() }
 }
 
-/// Captures part of the window and returns raw data.
-/// Example usage:
-/// ```rust,no_run
-/// use fltk::{prelude::*, *};
-/// let mut win = window::Window::default();
-/// let image = draw::capture_window(&mut win).unwrap();
-/// ```
-/// # Errors
-/// The api can fail to capture the window as an image
+/**!
+    Captures part of the window and returns raw data.
+    Example usage:
+    ```rust,no_run
+    use fltk::{prelude::*, *};
+    let mut win = window::Window::default();
+    let image = draw::capture_window(&mut win).unwrap();
+    ```
+    # Errors
+    The api can fail to capture the window as an image
+*/
 pub fn capture_window<Win: WindowExt>(win: &mut Win) -> Result<RgbImage, FltkError> {
     assert!(!win.was_deleted());
     let cp = win.width() * win.height() * 3;
@@ -828,14 +830,6 @@ pub fn draw_image(
 /// Errors on invalid or unsupported image formats
 /// # Safety
 /// Passing wrong line data can read to over or underflow
-pub unsafe fn draw_image2(
-    data: &[u8],
-    x: i32,
-    y: i32,
-    w: i32,
-    h: i32,
-    depth: i32,
-    line_data: i32,
-) {
+pub unsafe fn draw_image2(data: &[u8], x: i32, y: i32, w: i32, h: i32, depth: i32, line_data: i32) {
     Fl_draw_image(data.as_ptr(), x, y, w, h, depth, line_data);
 }

--- a/fltk/src/draw.rs
+++ b/fltk/src/draw.rs
@@ -682,7 +682,7 @@ pub fn reset_spot() {
     unsafe { Fl_reset_spot() }
 }
 
-/**!
+/**
     Captures part of the window and returns raw data.
     Example usage:
     ```rust,no_run

--- a/fltk/src/enums.rs
+++ b/fltk/src/enums.rs
@@ -1,5 +1,9 @@
 use crate::app::{font_index, FONTS};
+use crate::prelude::{FltkError, FltkErrorKind};
+use crate::utils::FlString;
 use fltk_sys::fl::Fl_get_rgb_color;
+use std::ffi::{CStr, CString};
+use std::path;
 
 /// Defines label types
 #[repr(i32)]
@@ -293,6 +297,55 @@ impl Font {
         match font_index(name) {
             Some(val) => Font::by_index(val),
             None => Font::Helvetica,
+        }
+    }
+
+    /**!
+        Replace a current font with a loaded font
+        ```rust,no_run
+        use fltk::enums::Font;
+        let font = Font::load_font("font.ttf").unwrap();
+        Font::set_font(Font::Helvetica, &font);
+        ```
+    */
+    pub fn set_font(old: Font, new: &str) {
+        let new = CString::safe_new(new);
+        unsafe {
+            fltk_sys::fl::Fl_set_font2(old.bits, new.as_ptr());
+        }
+    }
+
+    /**!
+        Load font from file
+        ```rust,no_run
+        use fltk::enums::Font;
+        let font = Font::load_font("font.ttf").unwrap();
+        Font::set_font(Font::Helvetica, &font);
+        ```
+    */
+    pub fn load_font<P: AsRef<path::Path>>(path: P) -> Result<String, FltkError> {
+        Font::load_font_(path.as_ref())
+    }
+
+    fn load_font_(path: &path::Path) -> Result<String, FltkError> {
+        unsafe {
+            if !path.exists() {
+                return Err::<String, FltkError>(FltkError::Internal(
+                    FltkErrorKind::ResourceNotFound,
+                ));
+            }
+            if let Some(p) = path.to_str() {
+                let path = CString::safe_new(p);
+                let ptr = fltk_sys::fl::Fl_load_font(path.as_ptr());
+                if ptr.is_null() {
+                    Err::<String, FltkError>(FltkError::Internal(FltkErrorKind::FailedOperation))
+                } else {
+                    let name = CStr::from_ptr(ptr as *mut _).to_string_lossy().to_string();
+                    Ok(name)
+                }
+            } else {
+                Err(FltkError::Internal(FltkErrorKind::ResourceNotFound))
+            }
         }
     }
 }

--- a/fltk/src/enums.rs
+++ b/fltk/src/enums.rs
@@ -177,6 +177,15 @@ impl FrameType {
     pub fn dh(self) -> i32 {
         unsafe { fltk_sys::fl::Fl_box_dh(self as i32) }
     }
+
+    /// Swap frames
+    pub fn swap_frames(old_frame: FrameType, new_frame: FrameType) {
+        unsafe {
+            let new_frame = new_frame as i32;
+            let old_frame = old_frame as i32;
+            fltk_sys::fl::Fl_set_box_type(old_frame, new_frame);
+        }
+    }
 }
 
 bitflags! {

--- a/fltk/src/enums.rs
+++ b/fltk/src/enums.rs
@@ -300,7 +300,7 @@ impl Font {
         }
     }
 
-    /**!
+    /**
         Replace a current font with a loaded font
         ```rust,no_run
         use fltk::enums::Font;
@@ -315,7 +315,7 @@ impl Font {
         }
     }
 
-    /**!
+    /**
         Load font from file
         ```rust,no_run
         use fltk::enums::Font;

--- a/fltk/src/group.rs
+++ b/fltk/src/group.rs
@@ -339,7 +339,7 @@ impl Pack {
     }
 }
 
-/**!
+/**
     Defines a Vertical Grid (custom widget).
     Requires setting the params manually using the `set_params` method, which takes the rows, columns and spacing.
     Requires explicit calls to add, which is overloaded especially for the layout.
@@ -423,7 +423,7 @@ impl DerefMut for VGrid {
     }
 }
 
-/**!
+/**
     Defines a Horizontal Grid (custom widget).
     Requires setting the params manually using the `set_params` method, which takes the rows, columns and spacing.
     Requires explicit calls to add, which is overloaded especially for the layout.

--- a/fltk/src/group.rs
+++ b/fltk/src/group.rs
@@ -339,22 +339,24 @@ impl Pack {
     }
 }
 
-/// Defines a Vertical Grid (custom widget).
-/// Requires setting the params manually using the `set_params` method, which takes the rows, columns and spacing.
-/// Requires explicit calls to add, which is overloaded especially for the layout.
-/// ```rust,no_run
-/// use fltk::{prelude::*, *};
-/// let mut grid = group::VGrid::new(0, 0, 400, 300, "");
-/// grid.set_params(3, 3, 5);
-/// grid.add(&button::Button::default());
-/// grid.add(&button::Button::default());
-/// grid.add(&button::Button::default());
-/// grid.add(&button::Button::default());
-/// grid.add(&button::Button::default());
-/// grid.add(&button::Button::default());
-/// grid.add(&button::Button::default());
-/// grid.add(&button::Button::default());
-/// ```
+/**!
+    Defines a Vertical Grid (custom widget).
+    Requires setting the params manually using the `set_params` method, which takes the rows, columns and spacing.
+    Requires explicit calls to add, which is overloaded especially for the layout.
+    ```rust,no_run
+    use fltk::{prelude::*, *};
+    let mut grid = group::VGrid::new(0, 0, 400, 300, "");
+    grid.set_params(3, 3, 5);
+    grid.add(&button::Button::default());
+    grid.add(&button::Button::default());
+    grid.add(&button::Button::default());
+    grid.add(&button::Button::default());
+    grid.add(&button::Button::default());
+    grid.add(&button::Button::default());
+    grid.add(&button::Button::default());
+    grid.add(&button::Button::default());
+    ```
+*/
 #[derive(Debug, Clone)]
 pub struct VGrid {
     vpack: Pack,
@@ -421,22 +423,24 @@ impl DerefMut for VGrid {
     }
 }
 
-/// Defines a Horizontal Grid (custom widget).
-/// Requires setting the params manually using the `set_params` method, which takes the rows, columns and spacing.
-/// Requires explicit calls to add, which is overloaded especially for the layout.
-/// ```rust,no_run
-/// use fltk::{prelude::*, *};
-/// let mut grid = group::HGrid::new(0, 0, 400, 300, "");
-/// grid.set_params(3, 3, 5);
-/// grid.add(&button::Button::default());
-/// grid.add(&button::Button::default());
-/// grid.add(&button::Button::default());
-/// grid.add(&button::Button::default());
-/// grid.add(&button::Button::default());
-/// grid.add(&button::Button::default());
-/// grid.add(&button::Button::default());
-/// grid.add(&button::Button::default());
-/// ```
+/**!
+    Defines a Horizontal Grid (custom widget).
+    Requires setting the params manually using the `set_params` method, which takes the rows, columns and spacing.
+    Requires explicit calls to add, which is overloaded especially for the layout.
+    ```rust,no_run
+    use fltk::{prelude::*, *};
+    let mut grid = group::HGrid::new(0, 0, 400, 300, "");
+    grid.set_params(3, 3, 5);
+    grid.add(&button::Button::default());
+    grid.add(&button::Button::default());
+    grid.add(&button::Button::default());
+    grid.add(&button::Button::default());
+    grid.add(&button::Button::default());
+    grid.add(&button::Button::default());
+    grid.add(&button::Button::default());
+    grid.add(&button::Button::default());
+    ```
+*/
 #[derive(Debug, Clone)]
 pub struct HGrid {
     hpack: Pack,

--- a/fltk/src/image.rs
+++ b/fltk/src/image.rs
@@ -270,9 +270,7 @@ impl SvgImage {
     /// Rasterize an SvgImage
     pub fn normalize(&mut self) {
         assert!(!self.was_deleted());
-        unsafe {
-            Fl_SVG_Image_normalize(self.inner)
-        }
+        unsafe { Fl_SVG_Image_normalize(self.inner) }
     }
 }
 
@@ -650,7 +648,13 @@ impl RgbImage {
     /// Errors on invalid or unsupported image format
     /// # Safety
     /// Passing wrong line data can read to over or underflow
-    pub unsafe fn new2(data: &[u8], w: i32, h: i32, depth: i32, line_data: i32) -> Result<RgbImage, FltkError> {
+    pub unsafe fn new2(
+        data: &[u8],
+        w: i32,
+        h: i32,
+        depth: i32,
+        line_data: i32,
+    ) -> Result<RgbImage, FltkError> {
         let img = Fl_RGB_Image_new(data.as_ptr(), w, h, depth, line_data);
         if img.is_null() || Fl_RGB_Image_fail(img) < 0 {
             Err(FltkError::Internal(FltkErrorKind::ImageFormatError))
@@ -674,7 +678,7 @@ impl RgbImage {
         w: i32,
         h: i32,
         depth: i32,
-        line_data: i32
+        line_data: i32,
     ) -> Result<RgbImage, FltkError> {
         let img = Fl_RGB_Image_from_data(data.as_ptr(), w, h, depth, line_data);
         if img.is_null() || Fl_RGB_Image_fail(img) < 0 {

--- a/fltk/src/lib.rs
+++ b/fltk/src/lib.rs
@@ -47,7 +47,7 @@ For faster builds you can enable ninja builds for the C++ source using the "use-
 
 An example hello world application:
 
-```no_run
+```rust,no_run
 use fltk::{app, prelude::*, window::Window};
 let app = app::App::default();
 let mut wind = Window::new(100, 100, 400, 300, "Hello from rust");
@@ -57,7 +57,7 @@ app.run().unwrap();
 ```
 
 Another example showing the basic callback functionality:
-```no_run
+```rust,no_run
 use fltk::{app, button::Button, frame::Frame, prelude::*, window::Window};
 let app = app::App::default();
 let mut wind = Window::new(100, 100, 400, 300, "Hello from rust");
@@ -71,7 +71,7 @@ app.run().unwrap();
 Please check the examples directory for more examples.
 You will notice that all widgets are instantiated with a new() method, taking the x and y coordinates, the width and height of the widget, as well as a label which can be left blank if needed. Another way to initialize a widget is using the builder pattern: (The following buttons are equivalent)
 
-```no_run
+```rust,no_run
 use fltk::{button::*, prelude::*};
 let but1 = Button::new(10, 10, 80, 40, "Button 1");
 
@@ -82,7 +82,7 @@ let but2 = Button::default()
 ```
 
 An example of a counter showing use of the builder pattern:
-```no_run
+```rust,no_run
 use fltk::{app, button::*, frame::*, prelude::*, window::*};
 let app = app::App::default();
 let mut wind = Window::default()
@@ -107,7 +107,7 @@ wind.show();
 /* Event handling */
 ```
 Alternatively, you can use packs to layout your widgets:
-```no_run
+```rust,no_run
 use fltk::{button::*, frame::*, group::*, prelude::*, window::*};
 let mut wind = Window::default().with_size(160, 200).with_label("Counter");
 // Vertical is default. You can choose horizontal using pack.set_type(PackType::Horizontal);

--- a/fltk/src/misc.rs
+++ b/fltk/src/misc.rs
@@ -597,12 +597,14 @@ impl InputChoice {
     }
 }
 
-/// Creates a `HelpView` widget which supports HTML 2 formatting
-/// ```rust,no_run
-/// use fltk::{prelude::*, *};
-/// let mut h = misc::HelpView::new(10, 10, 380, 280, "");
-/// h.set_value("Hello <b><font color=red>again</font></b>");
-/// ```
+/**!
+    Creates a `HelpView` widget which supports HTML 2 formatting
+    ```rust,no_run
+    use fltk::{prelude::*, *};
+    let mut h = misc::HelpView::new(10, 10, 380, 280, "");
+    h.set_value("Hello <b><font color=red>again</font></b>");
+    ```
+*/
 #[derive(WidgetBase, WidgetExt, Debug)]
 pub struct HelpView {
     inner: *mut Fl_Help_View,

--- a/fltk/src/misc.rs
+++ b/fltk/src/misc.rs
@@ -597,7 +597,7 @@ impl InputChoice {
     }
 }
 
-/**!
+/**
     Creates a `HelpView` widget which supports HTML 2 formatting
     ```rust,no_run
     use fltk::{prelude::*, *};

--- a/fltk/src/prelude.rs
+++ b/fltk/src/prelude.rs
@@ -330,6 +330,8 @@ pub unsafe trait WidgetBase: WidgetExt {
     /// * `width` - The width of the widget
     /// * `heigth` - The height of the widget
     /// * `title` - The title or label of the widget
+    /// The title is expected to be a static str or None. 
+    /// To use dynamic strings use `with_label(self, &str)` or `set_label(&mut self, &str)`
     /// labels support special symbols preceded by an `@` [sign](https://www.fltk.org/doc-1.3/symbols.png).
     /// and for the [associated formatting](https://www.fltk.org/doc-1.3/common.html).
     fn new<T: Into<Option<&'static str>>>(

--- a/fltk/src/printer.rs
+++ b/fltk/src/printer.rs
@@ -3,27 +3,29 @@ use crate::utils::FlString;
 use fltk_sys::printer::*;
 use std::ffi::CString;
 
-/// Defines a printer object.
-/// Example usage:
-/// ```rust,no_run
-/// use fltk::{prelude::*, *};
-/// let mut but = button::Button::default();
-/// but.set_callback(|widget| {
-///     let mut printer = printer::Printer::default();
-///     if printer.begin_job(1).is_ok() {
-///         printer.begin_page().ok();
-///         let (width, height) = printer.printable_rect();
-///         draw::set_draw_color(enums::Color::Black);
-///         draw::set_line_style(draw::LineStyle::Solid, 2);
-///         draw::draw_rect(0, 0, width, height);
-///         draw::set_font(enums::Font::Courier, 12);
-///         printer.set_origin(width / 2, height / 2);
-///         printer.print_widget(widget, -widget.width() / 2, -widget.height() / 2);
-///         printer.end_page().ok();
-///         printer.end_job();
-///     }
-/// });
-/// ```
+/**!
+    Defines a printer object.
+    Example usage:
+    ```rust,no_run
+    use fltk::{prelude::*, *};
+    let mut but = button::Button::default();
+    but.set_callback(|widget| {
+        let mut printer = printer::Printer::default();
+        if printer.begin_job(1).is_ok() {
+            printer.begin_page().ok();
+            let (width, height) = printer.printable_rect();
+            draw::set_draw_color(enums::Color::Black);
+            draw::set_line_style(draw::LineStyle::Solid, 2);
+            draw::draw_rect(0, 0, width, height);
+            draw::set_font(enums::Font::Courier, 12);
+            printer.set_origin(width / 2, height / 2);
+            printer.print_widget(widget, -widget.width() / 2, -widget.height() / 2);
+            printer.end_page().ok();
+            printer.end_job();
+        }
+    });
+    ```
+*/
 pub struct Printer {
     inner: *mut Fl_Printer,
 }

--- a/fltk/src/printer.rs
+++ b/fltk/src/printer.rs
@@ -3,7 +3,7 @@ use crate::utils::FlString;
 use fltk_sys::printer::*;
 use std::ffi::CString;
 
-/**!
+/**
     Defines a printer object.
     Example usage:
     ```rust,no_run

--- a/fltk/src/surface.rs
+++ b/fltk/src/surface.rs
@@ -4,19 +4,21 @@ use fltk_sys::surface::*;
 use std::ffi::CString;
 use std::path;
 
-/// An image surface object.
-/// Example usage:
-/// ```rust,no_run
-/// use fltk::{prelude::*, *};
-/// let but = button::Button::new(0, 0, 80, 40, "Click");
-/// let sur = surface::ImageSurface::new(but.width(), but.height(), false);
-/// surface::ImageSurface::push_current(&sur);
-/// draw::set_draw_color(enums::Color::White);
-/// draw::draw_rectf(0, 0, but.width(), but.height());
-/// sur.draw(&but, 0, 0);
-/// let img = sur.image().unwrap();
-/// surface::ImageSurface::pop_current();
-/// ```
+/**!
+    An image surface object.
+    Example usage:
+    ```rust,no_run
+    use fltk::{prelude::*, *};
+    let but = button::Button::new(0, 0, 80, 40, "Click");
+    let sur = surface::ImageSurface::new(but.width(), but.height(), false);
+    surface::ImageSurface::push_current(&sur);
+    draw::set_draw_color(enums::Color::White);
+    draw::draw_rectf(0, 0, but.width(), but.height());
+    sur.draw(&but, 0, 0);
+    let img = sur.image().unwrap();
+    surface::ImageSurface::pop_current();
+    ```
+*/
 pub struct ImageSurface {
     inner: *mut Fl_Image_Surface,
 }
@@ -132,21 +134,23 @@ impl Drop for ImageSurface {
     }
 }
 
-/// An SVG image surface object
-/// Example usage:
-/// ```rust,no_run
-/// use fltk::{prelude::*, *};
-/// let but = button::Button::new(0, 0, 80, 40, "Click");
-/// // We need the destructor of SvgFileSurface to actually create the image
-/// {
-///     let sur = surface::SvgFileSurface::new(but.width(), but.height(), "temp.svg");
-///     surface::SvgFileSurface::push_current(&sur);
-///     draw::set_draw_color(enums::Color::White);
-///     draw::draw_rectf(0, 0, but.width(), but.height());
-///     sur.draw(&but, 0, 0);
-///     surface::SvgFileSurface::pop_current();
-/// }
-/// ```
+/**!
+    An SVG image surface object
+    Example usage:
+    ```rust,no_run
+    use fltk::{prelude::*, *};
+    let but = button::Button::new(0, 0, 80, 40, "Click");
+    // We need the destructor of SvgFileSurface to actually create the image
+    {
+        let sur = surface::SvgFileSurface::new(but.width(), but.height(), "temp.svg");
+        surface::SvgFileSurface::push_current(&sur);
+        draw::set_draw_color(enums::Color::White);
+        draw::draw_rectf(0, 0, but.width(), but.height());
+        sur.draw(&but, 0, 0);
+        surface::SvgFileSurface::pop_current();
+    }
+    ```
+*/
 pub struct SvgFileSurface {
     inner: *mut Fl_SVG_File_Surface,
 }

--- a/fltk/src/surface.rs
+++ b/fltk/src/surface.rs
@@ -4,7 +4,7 @@ use fltk_sys::surface::*;
 use std::ffi::CString;
 use std::path;
 
-/**!
+/**
     An image surface object.
     Example usage:
     ```rust,no_run
@@ -134,7 +134,7 @@ impl Drop for ImageSurface {
     }
 }
 
-/**!
+/**
     An SVG image surface object
     Example usage:
     ```rust,no_run

--- a/fltk/src/text.rs
+++ b/fltk/src/text.rs
@@ -103,7 +103,7 @@ impl TextBuffer {
         }
     }
 
-    /**!
+    /**
         Appends to the buffer.
         To append and scroll to the end of the buffer:
         ```rust,no_run

--- a/fltk/src/text.rs
+++ b/fltk/src/text.rs
@@ -103,21 +103,23 @@ impl TextBuffer {
         }
     }
 
-    /// Appends to the buffer.
-    /// To append and scroll to the end of the buffer:
-    /// ```rust,no_run
-    /// use fltk::{prelude::*, *};
-    /// let txt = "Some long text!";
-    /// let buf = text::TextBuffer::default();
-    /// let mut disp = text::TextDisplay::default();
-    /// disp.set_buffer(Some(buf));
-    /// disp.buffer().unwrap().append(txt);
-    /// disp.set_insert_position(disp.buffer().unwrap().length());
-    /// disp.scroll(
-    ///     disp.count_lines(0, disp.buffer().unwrap().length(), true),
-    ///     0,
-    /// );
-    /// ```
+    /**!
+        Appends to the buffer.
+        To append and scroll to the end of the buffer:
+        ```rust,no_run
+        use fltk::{prelude::*, *};
+        let txt = "Some long text!";
+        let buf = text::TextBuffer::default();
+        let mut disp = text::TextDisplay::default();
+        disp.set_buffer(Some(buf));
+        disp.buffer().unwrap().append(txt);
+        disp.set_insert_position(disp.buffer().unwrap().length());
+        disp.scroll(
+            disp.count_lines(0, disp.buffer().unwrap().length(), true),
+            0,
+        );
+        ```
+    */
     pub fn append(&mut self, text: &str) {
         assert!(!self.inner.is_null());
         let text = CString::safe_new(text);

--- a/fltk/src/utils.rs
+++ b/fltk/src/utils.rs
@@ -16,34 +16,40 @@ impl FlString for CString {
     }
 }
 
-/// Convenience function to convert rgb to hex.
-/// Example:
-/// ```rust,no_run
-/// use fltk::utils::rgb2hex;
-/// let ret = rgb2hex(0, 255, 0); println!("0x{:06x}", ret);
-/// ```
+/**!
+    Convenience function to convert rgb to hex.
+    Example:
+    ```rust,no_run
+    use fltk::utils::rgb2hex;
+    let ret = rgb2hex(0, 255, 0); println!("0x{:06x}", ret);
+    ```
+*/
 pub fn rgb2hex(r: u8, g: u8, b: u8) -> u32 {
     // Shouldn't fail
     u32::from_str_radix(&format!("{:02x}{:02x}{:02x}", r, g, b), 16).unwrap()
 }
 
-/// Convenience function to convert rgba to hex.
-/// Example:
-/// ```rust,no_run
-/// use fltk::utils::rgba2hex;
-/// let ret = rgba2hex(0, 255, 0, 255); println!("0x{:08x}", ret);
-/// ```
+/**!
+    Convenience function to convert rgba to hex.
+    Example:
+    ```rust,no_run
+    use fltk::utils::rgba2hex;
+    let ret = rgba2hex(0, 255, 0, 255); println!("0x{:08x}", ret);
+    ```
+*/
 pub fn rgba2hex(r: u8, g: u8, b: u8, a: u8) -> u32 {
     // Shouldn't fail
     u32::from_str_radix(&format!("{:02x}{:02x}{:02x}{:02x}", r, g, b, a), 16).unwrap()
 }
 
-/// Convenience function to convert hex to rgb.
-/// Example:
-/// ```rust,no_run
-/// use fltk::utils::hex2rgb;
-/// let (r, g, b) = hex2rgb(0x000000);
-/// ```
+/**!
+    Convenience function to convert hex to rgb.
+    Example:
+    ```rust,no_run
+    use fltk::utils::hex2rgb;
+    let (r, g, b) = hex2rgb(0x000000);
+    ```
+*/
 pub fn hex2rgb(val: u32) -> (u8, u8, u8) {
     let hex = format!("{:06x}", val);
     let r = u8::from_str_radix(&hex[0..2], 16).unwrap();
@@ -52,12 +58,14 @@ pub fn hex2rgb(val: u32) -> (u8, u8, u8) {
     (r, g, b)
 }
 
-/// Convenience function to convert hex to rgba.
-/// Example:
-/// ```rust,no_run
-/// use fltk::utils::hex2rgba;
-/// let (r, g, b, a) = hex2rgba(0xff0000ff);
-/// ```
+/**!
+    Convenience function to convert hex to rgba.
+    Example:
+    ```rust,no_run
+    use fltk::utils::hex2rgba;
+    let (r, g, b, a) = hex2rgba(0xff0000ff);
+    ```
+*/
 pub fn hex2rgba(val: u32) -> (u8, u8, u8, u8) {
     let r = ((val >> 24) & 0xff) as u8;
     let g = ((val >> 16) & 0xff) as u8;

--- a/fltk/src/utils.rs
+++ b/fltk/src/utils.rs
@@ -16,7 +16,7 @@ impl FlString for CString {
     }
 }
 
-/**!
+/**
     Convenience function to convert rgb to hex.
     Example:
     ```rust,no_run
@@ -29,7 +29,7 @@ pub fn rgb2hex(r: u8, g: u8, b: u8) -> u32 {
     u32::from_str_radix(&format!("{:02x}{:02x}{:02x}", r, g, b), 16).unwrap()
 }
 
-/**!
+/**
     Convenience function to convert rgba to hex.
     Example:
     ```rust,no_run
@@ -42,7 +42,7 @@ pub fn rgba2hex(r: u8, g: u8, b: u8, a: u8) -> u32 {
     u32::from_str_radix(&format!("{:02x}{:02x}{:02x}{:02x}", r, g, b, a), 16).unwrap()
 }
 
-/**!
+/**
     Convenience function to convert hex to rgb.
     Example:
     ```rust,no_run
@@ -58,7 +58,7 @@ pub fn hex2rgb(val: u32) -> (u8, u8, u8) {
     (r, g, b)
 }
 
-/**!
+/**
     Convenience function to convert hex to rgba.
     Example:
     ```rust,no_run


### PR DESCRIPTION
- Update app::set_callback to reflect WidgetExt::set_callback.
- Add app::swap_frame_type() to swap the default frame type with a new one.
- Add app::frame_type() to get the default frame type.
- Add enums::FrameType::swap_frames() to swap frame types.
- Free WindowExt::raw_handle() memory on error.
- Use full font name instead of family name when handling external truetype fonts.
- Add convenience functions to enums::Font for loading and replacing fonts.
