### PR TITLE
1.0.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 
+## [1.0.18] - 2021-06-08
+- Fix Font::set_font(), FLTK expects a long lived string.
+
 ## [1.0.17] - 2021-06-07
 - Update app::set_callback to reflect WidgetExt::set_callback.
 - Add app::swap_frame_type() to swap the default frame type with a new one.

--- a/fltk/Cargo.toml
+++ b/fltk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk"
-version = "1.0.17"
+version = "1.0.18"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 edition = "2018"
 description = "Rust bindings for the FLTK GUI library"

--- a/fltk/src/app.rs
+++ b/fltk/src/app.rs
@@ -1185,6 +1185,7 @@ fn load_font(path: &str) -> Result<String, FltkError> {
             } else {
                 f[16] = name.clone();
             }
+            fl::Fl_set_font2(16, ptr);
             Ok(name)
         }
     }

--- a/fltk/src/enums.rs
+++ b/fltk/src/enums.rs
@@ -311,7 +311,7 @@ impl Font {
     pub fn set_font(old: Font, new: &str) {
         let new = CString::safe_new(new);
         unsafe {
-            fltk_sys::fl::Fl_set_font2(old.bits, new.as_ptr());
+            fltk_sys::fl::Fl_set_font2(old.bits, new.into_raw() as _);
         }
     }
 


### PR DESCRIPTION
- Fix Font::set_font(), FLTK expects a long lived string.
