### PR TITLE
A trivial, nonconsequential, fix to the calculator examples.

### DIFF
--- a/fltk/examples/calculator.rs
+++ b/fltk/examples/calculator.rs
@@ -226,6 +226,9 @@ fn main() {
                         if val.len() > 1 {
                             txt.pop();
                             out.set_value(txt.as_str());
+                        } else if val.len() == 1 {
+                            txt.pop();
+                            out.set_value("0");
                         }
                     }
                     Ops::CE => {

--- a/fltk/examples/calculator2.rs
+++ b/fltk/examples/calculator2.rs
@@ -244,6 +244,9 @@ fn main() {
                         if val.len() > 1 {
                             txt.pop();
                             out.set_value(txt.as_str());
+                        } else if val.len() == 1 {
+                            txt.pop();
+                            out.set_value("0");
                         }
                     }
                     Ops::CE => {


### PR DESCRIPTION
Makes is possible to backspace all the way to 0.

Before this change the last digit would remain. 
Example: enter 99, click 'backspace' twice or more -> 9 remains