### PR TITLE
Fixed spreadsheet example

### DIFF
--- a/fltk/examples/spreadsheet.rs
+++ b/fltk/examples/spreadsheet.rs
@@ -87,7 +87,10 @@ impl MyTable {
         let data_c = data.clone();
 
         table.handle(move |_, ev| match ev {
-            enums::Event::Push => {
+            // Event::Push will happen before the focus is moved,
+            // thus giving the previous coordinates.
+            // Event::Released gives an accurate position
+            enums::Event::Released => {
                 let c = cell_c.borrow();
                 inp.resize(c.x, c.y, c.w, c.h);
                 inp.set_value(&data_c.borrow_mut()[c.row as usize][c.col as usize]);


### PR DESCRIPTION
Yet another example fix that does not actually fix anything critical, just some spit and polish :)

This PR will fix this issue:

Run spreadsheet example
click field A1, type "A1" (no visible edit field) and enter.  Field A1 now contains "A1"
click field B1, type "B1" (looks like A1 is being edited) and enter. Field B1 now contains "A1B1"
click field C1, type "C1" (looks like B1 is being edited)and enter.  Field C1 now contains "A1B1C1"

Expected behavior:
click field A1, type "A1" (looks like A1 is being edited) and enter.  field A1 now contains "A1"
click field B1, type "B1" (looks like B1 is being edited) and enter.  field B1 now contains "B1"
click field C1, type "C1" (looks like C1 is being edited) and enter.  field C1 now contains "C1"

What the PR does is to change it so that it will listen for Events::Released instead of Event::Push.
The push event will happen before the focus is moved, so the input field is getting initial data and position from the wrong cell.

The example does not work if you, for example, select the cell with the arrow keys. But neither did it before this PR and it's just an example, after all.

Tested the issue and fix on Linux and macOs.