### PR TITLE
1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-## [1.1.0] - Unreleased
+## [1.1.0] - 2021-07-10
 - Largely simplify getting concrete types, ex. Scroll::scrollbar() now returns a concrete Scrollbar instead of a `Box<dyn ValuatorExt>`, and parent() returns an `Option<Group>` instead of an `Option<Box<dyn GroupExt>>`.
 - Add Window::opacity() and set_opacity() to support window transparency/opacity.
 - Add MenuItem::add_image() to add icons to menu items.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Add overloads for `app::*_idle` and `app::*_timeout` which accept simple function pointers.
 - Fix app::event_clicks() and add overload for event_clicks_num() for number of clicks.
 - Add a Flex widget (which supports Flexbox layouts).
-- Support `::end` calls for Column and Row widgets.
+- Support `::new` and `::end` calls for Column and Row widgets.
 - Support `::end` calls for VGrid and HGrid widgets.
 
 ## [1.1.0] - 2021-07-10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 # Changelog
 
 
-## [1.1.1] - Unreleased
+## [1.1.1] - 2021-07-18
 - Add overloads for `app::*_idle` and `app::*_timeout` which accept simple function pointers.
 - Fix app::event_clicks() and add overload for event_clicks_num() for number of clicks.
 - Add a Flex widget (which supports Flexbox layouts).
 - Support `::new` and `::end` calls for Column and Row widgets.
 - Support `::end` calls for VGrid and HGrid widgets.
+- Update libc and FLTK.
 
 ## [1.1.0] - 2021-07-10
 - Largely simplify getting concrete types, ex. Scroll::scrollbar() now returns a concrete Scrollbar instead of a `Box<dyn ValuatorExt>`, and parent() returns an `Option<Group>` instead of an `Option<Box<dyn GroupExt>>`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 ## [1.1.1] - Unreleased
 - Add overloads for `app::*_idle` and `app::*_timeout` which accept simple function pointers.
 - Fix app::event_clicks() and add overload for event_clicks_num() for number of clicks.
+- Add a Flex widget (which supports Flexbox layouts).
+- Support `::end` calls for Column and Row widgets.
+- Support `::end` calls for VGrid and HGrid widgets.
 
 ## [1.1.0] - 2021-07-10
 - Largely simplify getting concrete types, ex. Scroll::scrollbar() now returns a concrete Scrollbar instead of a `Box<dyn ValuatorExt>`, and parent() returns an `Option<Group>` instead of an `Option<Box<dyn GroupExt>>`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 
+## [1.1.1] - Unreleased
+- Add overloads for `app::*_idle` and `app::*_timeout` which accept simple function pointers.
+- Fix app::event_clicks() and add overload for event_clicks_num() for number of clicks.
+
 ## [1.1.0] - 2021-07-10
 - Largely simplify getting concrete types, ex. Scroll::scrollbar() now returns a concrete Scrollbar instead of a `Box<dyn ValuatorExt>`, and parent() returns an `Option<Group>` instead of an `Option<Box<dyn GroupExt>>`.
 - Add Window::opacity() and set_opacity() to support window transparency/opacity.

--- a/README.md
+++ b/README.md
@@ -215,8 +215,8 @@ The following are the features offered by the crate:
 
 Rust (version > 1.45), CMake (version > 3.0), Git and a C++11 compiler need to be installed and in your PATH for a crossplatform build from source. This crate also offers a bundled form of fltk on selected platforms (win 10 x64, macos 10.15 x64, linux x64), this can be enabled using the `fltk-bundled` feature-flag (which requires curl and tar to download and unpack the bundled libraries).
 
-- Windows: No dependencies.
-- MacOS: No dependencies.
+- Windows: No external dependencies.
+- MacOS: No external dependencies.
 - Linux/BSD: X11 and OpenGL development headers need to be installed for development. The libraries themselves are available on linux distros with a graphical user interface.
 
 For Debian-based GUI distributions, that means running:

--- a/README.md
+++ b/README.md
@@ -394,6 +394,7 @@ Various advanced examples can also be found [here](https://github.com/wyhinton/F
     - HGrid
     - Column (vertical pack supporting auto layout)
     - Row (horizontal pack supporting auto layout)
+    - Flex (Supports flexbox layouts)
 - Text display widgets
     - TextDisplay
     - TextEditor

--- a/fltk-sys/Cargo.toml
+++ b/fltk-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk-sys"
-version = "1.1.0"
+version = "1.1.1"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 build = "build/main.rs"
 edition = "2018"
@@ -14,7 +14,7 @@ name = "fltk_sys"
 path = "src/lib.rs"
 
 [dependencies]
-libc = "0.2.97"
+libc = "0.2.98"
 
 [build-dependencies]
 cmake = "^0.1.45"

--- a/fltk/Cargo.toml
+++ b/fltk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk"
-version = "1.1.0"
+version = "1.1.1"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 edition = "2018"
 description = "Rust bindings for the FLTK GUI library"
@@ -17,7 +17,7 @@ name = "fltk"
 path = "src/lib.rs"
 
 [dependencies]
-fltk-sys = { path = "../fltk-sys", version = "=1.1.0" }
+fltk-sys = { path = "../fltk-sys", version = "=1.1.1" }
 fltk-derive = { path = "../fltk-derive", version = "=1.1.0" }
 lazy_static = "^1.4.0"
 bitflags = "^1.2.1"

--- a/fltk/src/app/event.rs
+++ b/fltk/src/app/event.rs
@@ -71,9 +71,14 @@ pub fn event_mouse_button() -> MouseButton {
     unsafe { mem::transmute(fl::Fl_event_button()) }
 }
 
-/// Returns the number of clicks
+/// Returns false for a single click and true for more
 pub fn event_clicks() -> bool {
     unsafe { fl::Fl_event_clicks() != 0 }
+}
+
+/// Returns the number of clicks
+pub fn event_clicks_num() -> i32 {
+    unsafe { fl::Fl_event_clicks() }
 }
 
 /// Gets the x coordinate of the mouse in the window

--- a/fltk/src/app/event.rs
+++ b/fltk/src/app/event.rs
@@ -76,7 +76,7 @@ pub fn event_clicks() -> bool {
     unsafe { fl::Fl_event_clicks() != 0 }
 }
 
-/// Returns the number of clicks
+/// Returns the number of clicks - 1
 pub fn event_clicks_num() -> i32 {
     unsafe { fl::Fl_event_clicks() }
 }

--- a/fltk/src/app/rt.rs
+++ b/fltk/src/app/rt.rs
@@ -283,3 +283,75 @@ pub fn has_timeout<F: FnMut() + 'static>(cb: F) -> bool {
         fltk_sys::fl::Fl_has_timeout(callback, data) != 0
     }
 }
+
+/**
+    Adds a one-shot timeout callback. The timeout duration `tm` is indicated in seconds
+    Example:
+    ```rust,no_run
+    use fltk::{prelude::*, *};
+    fn callback() {
+        println!("TICK");
+        app::repeat_timeout2(1.0, callback);
+    }
+    fn main() {
+        let app = app::App::default();
+        let mut wind = window::Window::new(100, 100, 400, 300, "");
+        wind.show();
+        app::add_timeout2(1.0, callback);
+        app.run().unwrap();
+    }
+    ```
+*/
+pub fn add_timeout2(tm: f64, cb: fn()) {
+    unsafe {
+        let data: *mut raw::c_void = std::ptr::null_mut();
+        let callback: Option<unsafe extern "C" fn(arg1: *mut raw::c_void)> = Some(std::mem::transmute(cb));
+        fltk_sys::fl::Fl_add_timeout2(tm, callback, data);
+    }
+}
+
+/**
+    Repeats a timeout callback from the expiration of the previous timeout.
+    You may only call this method inside a timeout callback.
+    The timeout duration `tm` is indicated in seconds
+    Example:
+    ```rust,no_run
+    use fltk::{prelude::*, *};
+    fn callback() {
+        println!("TICK");
+        app::repeat_timeout(1.0, callback);
+    }
+    fn main() {
+        let app = app::App::default();
+        let mut wind = window::Window::new(100, 100, 400, 300, "");
+        wind.show();
+        app::add_timeout(1.0, callback);
+        app.run().unwrap();
+    }
+    ```
+*/
+pub fn repeat_timeout2(tm: f64, cb: fn()) {
+    unsafe {
+        let data: *mut raw::c_void = std::ptr::null_mut();
+        let callback: Option<unsafe extern "C" fn(arg1: *mut raw::c_void)> = Some(std::mem::transmute(cb));
+        fltk_sys::fl::Fl_repeat_timeout(tm, callback, data);
+    }
+}
+
+/// Removes a timeout callback
+pub fn remove_timeout2(cb: fn()) {
+    unsafe {
+        let data: *mut raw::c_void = std::ptr::null_mut();
+        let callback: Option<unsafe extern "C" fn(arg1: *mut raw::c_void)> = Some(std::mem::transmute(cb));
+        fltk_sys::fl::Fl_remove_timeout(callback, data);
+    }
+}
+
+/// Check whether a timeout is installed
+pub fn has_timeout2(cb: fn()) -> bool {
+    unsafe {
+        let data: *mut raw::c_void = std::ptr::null_mut();
+        let callback: Option<unsafe extern "C" fn(arg1: *mut raw::c_void)> = Some(std::mem::transmute(cb));
+        fltk_sys::fl::Fl_has_timeout(callback, data) != 0
+    }
+}

--- a/fltk/src/app/rt.rs
+++ b/fltk/src/app/rt.rs
@@ -3,7 +3,7 @@ use crate::app::{
 };
 use crate::prelude::*;
 use fltk_sys::fl;
-use std::{os::raw, panic, sync::atomic::Ordering, thread, time};
+use std::{mem, os::raw, panic, sync::atomic::Ordering, thread, time};
 
 /// Runs the event loop
 /// # Errors
@@ -188,6 +188,34 @@ pub fn has_idle<F: FnMut() + 'static>(cb: F) -> bool {
     }
 }
 
+/// Add an idle callback to run within the event loop.
+/// Calls to `WidgetExt::redraw` within the callback require an explicit sleep
+pub fn add_idle2(cb: fn()) {
+    unsafe {
+        let data: *mut raw::c_void = std::ptr::null_mut();
+        let callback: Option<unsafe extern "C" fn(arg1: *mut raw::c_void)> = Some(mem::transmute(cb));
+        fl::Fl_add_idle(callback, data);
+    }
+}
+
+/// Remove an idle function
+pub fn remove_idle2(cb: fn()) {
+    unsafe {
+        let data: *mut raw::c_void = std::ptr::null_mut();
+        let callback: Option<unsafe extern "C" fn(arg1: *mut raw::c_void)> = Some(mem::transmute(cb));
+        fl::Fl_remove_idle(callback, data);
+    }
+}
+
+/// Checks whether an idle function is installed
+pub fn has_idle2(cb: fn()) -> bool {
+    unsafe {
+        let data: *mut raw::c_void = std::ptr::null_mut();
+        let callback: Option<unsafe extern "C" fn(arg1: *mut raw::c_void)> = Some(mem::transmute(cb));
+        fl::Fl_has_idle(callback, data) != 0
+    }
+}
+
 /**
     Adds a one-shot timeout callback. The timeout duration `tm` is indicated in seconds
     Example:
@@ -305,7 +333,7 @@ pub fn has_timeout<F: FnMut() + 'static>(cb: F) -> bool {
 pub fn add_timeout2(tm: f64, cb: fn()) {
     unsafe {
         let data: *mut raw::c_void = std::ptr::null_mut();
-        let callback: Option<unsafe extern "C" fn(arg1: *mut raw::c_void)> = Some(std::mem::transmute(cb));
+        let callback: Option<unsafe extern "C" fn(arg1: *mut raw::c_void)> = Some(mem::transmute(cb));
         fltk_sys::fl::Fl_add_timeout(tm, callback, data);
     }
 }
@@ -333,7 +361,7 @@ pub fn add_timeout2(tm: f64, cb: fn()) {
 pub fn repeat_timeout2(tm: f64, cb: fn()) {
     unsafe {
         let data: *mut raw::c_void = std::ptr::null_mut();
-        let callback: Option<unsafe extern "C" fn(arg1: *mut raw::c_void)> = Some(std::mem::transmute(cb));
+        let callback: Option<unsafe extern "C" fn(arg1: *mut raw::c_void)> = Some(mem::transmute(cb));
         fltk_sys::fl::Fl_repeat_timeout(tm, callback, data);
     }
 }
@@ -342,7 +370,7 @@ pub fn repeat_timeout2(tm: f64, cb: fn()) {
 pub fn remove_timeout2(cb: fn()) {
     unsafe {
         let data: *mut raw::c_void = std::ptr::null_mut();
-        let callback: Option<unsafe extern "C" fn(arg1: *mut raw::c_void)> = Some(std::mem::transmute(cb));
+        let callback: Option<unsafe extern "C" fn(arg1: *mut raw::c_void)> = Some(mem::transmute(cb));
         fltk_sys::fl::Fl_remove_timeout(callback, data);
     }
 }
@@ -351,7 +379,7 @@ pub fn remove_timeout2(cb: fn()) {
 pub fn has_timeout2(cb: fn()) -> bool {
     unsafe {
         let data: *mut raw::c_void = std::ptr::null_mut();
-        let callback: Option<unsafe extern "C" fn(arg1: *mut raw::c_void)> = Some(std::mem::transmute(cb));
+        let callback: Option<unsafe extern "C" fn(arg1: *mut raw::c_void)> = Some(mem::transmute(cb));
         fltk_sys::fl::Fl_has_timeout(callback, data) != 0
     }
 }

--- a/fltk/src/app/rt.rs
+++ b/fltk/src/app/rt.rs
@@ -306,7 +306,7 @@ pub fn add_timeout2(tm: f64, cb: fn()) {
     unsafe {
         let data: *mut raw::c_void = std::ptr::null_mut();
         let callback: Option<unsafe extern "C" fn(arg1: *mut raw::c_void)> = Some(std::mem::transmute(cb));
-        fltk_sys::fl::Fl_add_timeout2(tm, callback, data);
+        fltk_sys::fl::Fl_add_timeout(tm, callback, data);
     }
 }
 

--- a/fltk/src/app/rt.rs
+++ b/fltk/src/app/rt.rs
@@ -347,13 +347,13 @@ pub fn add_timeout2(tm: f64, cb: fn()) {
     use fltk::{prelude::*, *};
     fn callback() {
         println!("TICK");
-        app::repeat_timeout(1.0, callback);
+        app::repeat_timeout2(1.0, callback);
     }
     fn main() {
         let app = app::App::default();
         let mut wind = window::Window::new(100, 100, 400, 300, "");
         wind.show();
-        app::add_timeout(1.0, callback);
+        app::add_timeout2(1.0, callback);
         app.run().unwrap();
     }
     ```

--- a/fltk/src/group.rs
+++ b/fltk/src/group.rs
@@ -260,9 +260,7 @@ impl Wizard {
     pub fn current_widget(&mut self) -> Widget {
         unsafe {
             assert!(!self.was_deleted());
-            Widget::from_widget_ptr(
-                Fl_Wizard_value(self.inner) as *mut fltk_sys::widget::Fl_Widget
-            )
+            Widget::from_widget_ptr(Fl_Wizard_value(self.inner) as *mut fltk_sys::widget::Fl_Widget)
         }
     }
 
@@ -349,19 +347,19 @@ impl Pack {
 /**
     Defines a Vertical Grid (custom widget).
     Requires setting the params manually using the `set_params` method, which takes the rows, columns and spacing.
-    Requires explicit calls to add, which is overloaded especially for the layout.
     ```rust,no_run
     use fltk::{prelude::*, *};
     let mut grid = group::VGrid::new(0, 0, 400, 300, "");
     grid.set_params(3, 3, 5);
-    grid.add(&button::Button::default());
-    grid.add(&button::Button::default());
-    grid.add(&button::Button::default());
-    grid.add(&button::Button::default());
-    grid.add(&button::Button::default());
-    grid.add(&button::Button::default());
-    grid.add(&button::Button::default());
-    grid.add(&button::Button::default());
+    button::Button::default();
+    button::Button::default();
+    button::Button::default();
+    button::Button::default();
+    button::Button::default();
+    button::Button::default();
+    button::Button::default();
+    button::Button::default();
+    grid.end();
     ```
 */
 #[derive(Debug, Clone)]
@@ -376,7 +374,6 @@ impl VGrid {
     /// Creates a new vertical grid
     pub fn new<T: Into<Option<&'static str>>>(x: i32, y: i32, w: i32, h: i32, label: T) -> VGrid {
         let vpack = Pack::new(x, y, w, h, label);
-        vpack.end();
         VGrid {
             vpack,
             rows: 1,
@@ -403,7 +400,9 @@ impl VGrid {
 
     /// Adds widgets to the grid
     pub fn add<W: WidgetExt>(&mut self, w: &W) {
-        let rem = self.current / self.cols;
+        self.current += 1;
+        debug_assert!(self.current <= self.rows * self.cols);
+        let rem = (self.current - 1) / self.cols;
         if rem < self.rows {
             let hpack = self.vpack.child(rem as i32).unwrap();
             let mut hpack = unsafe { Pack::from_widget_ptr(hpack.as_widget_ptr()) };
@@ -411,8 +410,33 @@ impl VGrid {
             hpack.add(w);
             hpack.auto_layout();
             self.vpack.auto_layout();
-            self.current += 1;
         }
+    }
+
+    /// End the grid
+    pub fn end(&mut self) {
+        use std::collections::VecDeque;
+        let children = self.vpack.children();
+        self.current = children - self.rows;
+        debug_assert!(self.current <= self.rows * self.cols);
+        let mut v = VecDeque::new();
+        for i in self.rows..children {
+            let c = self.vpack.child(i).unwrap();
+            v.push_back(c);
+        }
+        for i in 0..self.rows {
+            let hpack = self.vpack.child(i as i32).unwrap();
+            let mut hpack = unsafe { Pack::from_widget_ptr(hpack.as_widget_ptr()) };
+            hpack.end();
+            for _j in 0..self.cols {
+                if let Some(w) = v.pop_front() {
+                    self.vpack.remove(&w);
+                    hpack.add(&w);
+                }
+                hpack.auto_layout();
+            }
+        }
+        self.vpack.auto_layout();
     }
 }
 
@@ -433,19 +457,19 @@ impl DerefMut for VGrid {
 /**
     Defines a Horizontal Grid (custom widget).
     Requires setting the params manually using the `set_params` method, which takes the rows, columns and spacing.
-    Requires explicit calls to add, which is overloaded especially for the layout.
     ```rust,no_run
     use fltk::{prelude::*, *};
     let mut grid = group::HGrid::new(0, 0, 400, 300, "");
     grid.set_params(3, 3, 5);
-    grid.add(&button::Button::default());
-    grid.add(&button::Button::default());
-    grid.add(&button::Button::default());
-    grid.add(&button::Button::default());
-    grid.add(&button::Button::default());
-    grid.add(&button::Button::default());
-    grid.add(&button::Button::default());
-    grid.add(&button::Button::default());
+    button::Button::default();
+    button::Button::default();
+    button::Button::default();
+    button::Button::default();
+    button::Button::default();
+    button::Button::default();
+    button::Button::default();
+    button::Button::default();
+    grid.end();
     ```
 */
 #[derive(Debug, Clone)]
@@ -461,7 +485,6 @@ impl HGrid {
     pub fn new<T: Into<Option<&'static str>>>(x: i32, y: i32, w: i32, h: i32, label: T) -> HGrid {
         let mut hpack = Pack::new(x, y, w, h, label);
         hpack.set_type(PackType::Horizontal);
-        hpack.end();
         HGrid {
             hpack,
             rows: 1,
@@ -487,7 +510,9 @@ impl HGrid {
 
     /// Adds widgets to the grid
     pub fn add<W: WidgetExt>(&mut self, w: &W) {
-        let rem = self.current / self.rows;
+        self.current += 1;
+        debug_assert!(self.current <= self.rows * self.cols);
+        let rem = (self.current - 1) / self.rows;
         if rem < self.cols {
             let vpack = self.hpack.child(rem as i32).unwrap();
             let mut vpack = unsafe { Pack::from_widget_ptr(vpack.as_widget_ptr()) };
@@ -495,8 +520,33 @@ impl HGrid {
             vpack.add(w);
             vpack.auto_layout();
             self.hpack.auto_layout();
-            self.current += 1;
         }
+    }
+
+    /// End the grid
+    pub fn end(&mut self) {
+        use std::collections::VecDeque;
+        let children = self.hpack.children();
+        self.current = children - self.cols;
+        debug_assert!(self.current <= self.rows * self.cols);
+        let mut v = VecDeque::new();
+        for i in self.cols..children {
+            let c = self.hpack.child(i).unwrap();
+            v.push_back(c);
+        }
+        for i in 0..self.cols {
+            let vpack = self.hpack.child(i as i32).unwrap();
+            let mut vpack = unsafe { Pack::from_widget_ptr(vpack.as_widget_ptr()) };
+            vpack.end();
+            for _j in 0..self.rows {
+                if let Some(w) = v.pop_front() {
+                    self.hpack.remove(&w);
+                    vpack.add(&w);
+                }
+                vpack.auto_layout();
+            }
+        }
+        self.hpack.auto_layout();
     }
 }
 
@@ -524,12 +574,17 @@ impl Column {
     pub fn default() -> Self {
         let mut p = Pack::default().size_of_parent().center_of_parent();
         p.set_type(PackType::Vertical);
-        p.end();
         Column { p }
     }
+
     /// Add a widget to the column with automatic layouting
     pub fn add<W: WidgetExt>(&mut self, w: &W) {
         self.p.add(w);
+        self.p.auto_layout();
+    }
+
+    /// End the column
+    pub fn end(&mut self) {
         self.p.auto_layout();
     }
 }
@@ -558,12 +613,17 @@ impl Row {
     pub fn default() -> Self {
         let mut p = Pack::default().size_of_parent().center_of_parent();
         p.set_type(PackType::Horizontal);
-        p.end();
         Row { p }
     }
+
     /// Add a widget to the row with automatic layouting
     pub fn add<W: WidgetExt>(&mut self, w: &W) {
         self.p.add(w);
+        self.p.auto_layout();
+    }
+
+    /// End the row
+    pub fn end(&mut self) {
         self.p.auto_layout();
     }
 }
@@ -579,5 +639,203 @@ impl Deref for Row {
 impl DerefMut for Row {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.p
+    }
+}
+
+/// Defines Flex types
+#[repr(i32)]
+#[derive(WidgetType, Debug, Copy, Clone, PartialEq)]
+pub enum FlexType {
+    /// row direction
+    Row = 0,
+    /// column direction
+    Column,
+}
+
+/** 
+    a Flexbox widget
+    # Example
+    ```rust,no_run
+    use fltk::{prelude::*, *};
+    let mut col = group::Flex::new(0, 0, 400, 300, None);
+    col.set_type(group::FlexType::Column);
+    let expanding = button::Button::default().with_label("Expanding");
+    let mut normal = button::Button::default().with_label("Normal");
+    col.set_size(&mut normal, 30);
+    col.end();
+    ```
+*/
+pub struct Flex {
+    grp: Group,
+    dir: FlexType,
+    margin: i32,
+    pad: i32,
+    setsized: Vec<Widget>,
+}
+
+impl Flex {
+    /// Create a new Flex widget
+    pub fn new<T: Into<Option<&'static str>>>(x: i32, y: i32, w: i32, h: i32, label: T) -> Flex {
+        let dir = FlexType::Row;
+        let margin = 0;
+        let pad = 5;
+        let grp = Group::new(x, y, w, h, label);
+        Self {
+            grp,
+            dir,
+            margin,
+            pad,
+            setsized: Vec::new(),
+        }
+    }
+
+    /// Set the direction
+    pub fn set_type<T: WidgetType>(&mut self, typ: T) {
+        self.dir = FlexType::from_i32(typ.to_i32());
+    }
+
+    /// Get the direction
+    pub fn get_type<T: WidgetType>(&self) -> T {
+        T::from_i32(self.dir.to_i32())
+    }
+
+    /// End the Flex widget
+    pub fn end(&mut self) {
+        self.grp.end();
+        self.resize(self.grp.x(), self.grp.y(), self.grp.w(), self.grp.h());
+    }
+
+    /// Set the size of the widget
+    pub fn set_size<W: WidgetExt>(&mut self, wid: &mut W, size: i32) {
+        wid.resize(0, 0, size, size);
+
+        for i in 0..self.setsized.len() {
+            if unsafe { self.setsized[i].as_widget_ptr() == wid.as_widget_ptr() } {
+                return;
+            }
+        }
+
+        self.setsized
+            .push(unsafe { Widget::from_widget_ptr(wid.as_widget_ptr()) });
+    }
+
+    /// Resize the Flex widget
+    pub fn resize(&mut self, x: i32, y: i32, w: i32, h: i32) {
+        self.grp.resize(x, y, w, h);
+        if self.dir == FlexType::Column {
+            self.resize_col(x, y, w, h);
+        } else {
+            self.resize_row(x, y, w, h);
+        }
+    }
+
+    fn is_set_size<W: WidgetExt>(&self, wid: &W) -> bool {
+        for i in 0..self.setsized.len() {
+            if unsafe { wid.as_widget_ptr() == self.setsized[i].as_widget_ptr() } {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    fn resize_row(&mut self, x: i32, y: i32, w: i32, h: i32) {
+        let cc = self.grp.children();
+        let mut pad_w = w - self.margin * 2;
+
+        // Calculate total width minus padding
+        for _i in 0..cc {
+            pad_w -= 5;
+        }
+
+        let mut cx = x + self.margin;
+        let mut nrs = 0;
+
+        // Precalculate remaining size to resize to
+        // Calculate non-resizable width total
+        for i in 0..cc {
+            let c = self.grp.child(i).unwrap();
+
+            if self.is_set_size(&c) {
+                nrs += c.w();
+            }
+        }
+
+        // Set children to shared width of remaining
+        for i in 0..cc {
+            let mut c = self.grp.child(i).unwrap();
+
+            if self.is_set_size(&c) {
+                c.resize(cx, y + self.margin, c.w(), h - self.margin * 2);
+            } else {
+                c.resize(
+                    cx,
+                    y + self.margin,
+                    (pad_w - nrs) / (cc - self.setsized.len() as i32),
+                    h - self.margin * 2,
+                );
+            }
+
+            cx += c.w() + self.pad;
+        }
+    }
+
+    fn resize_col(&mut self, x: i32, y: i32, w: i32, h: i32) {
+        let cc = self.grp.children();
+        let mut pad_h = h - self.margin * 2;
+
+        // Calculate total height minus padding
+        for _i in 0..cc {
+            pad_h -= self.pad;
+        }
+
+        let mut cy = y + self.margin;
+        let mut nrs = 0;
+
+        // Precalculate remaining size to resize to
+        // Calculate non-resizable height total
+        for i in 0..cc {
+            let c = self.grp.child(i).unwrap();
+
+            if self.is_set_size(&c) {
+                nrs += c.h();
+            }
+        }
+
+        // Set children to shared width of remaining
+        for i in 0..cc {
+            let mut c = self.grp.child(i).unwrap();
+
+            if self.is_set_size(&c) {
+                c.resize(x + self.margin, cy, w - self.margin * 2, c.h());
+            } else {
+                // [cc - (int)setsized.size()] allows negative.
+                // This is very handy to allow resizable items to have negative height
+                // allowing one on the top and bottom to center contents even if container
+                // is too small.
+                c.resize(
+                    x + self.margin,
+                    cy,
+                    w - self.margin * 2,
+                    (pad_h - nrs) / (cc - self.setsized.len() as i32),
+                );
+            }
+
+            cy += c.h() + self.pad;
+        }
+    }
+}
+
+impl Deref for Flex {
+    type Target = Group;
+
+    fn deref(&self) -> &Self::Target {
+        &self.grp
+    }
+}
+
+impl DerefMut for Flex {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.grp
     }
 }

--- a/fltk/src/group.rs
+++ b/fltk/src/group.rs
@@ -572,8 +572,8 @@ pub struct Column {
 impl Column {
     /// Create a new column
     pub fn new<T: Into<Option<&'static str>>>(x: i32, y: i32, w: i32, h: i32, label: T) -> Column {
-        let mut p = Pack::new(x, y, w, h, label);
-        Row { p }
+        let p = Pack::new(x, y, w, h, label);
+        Column { p }
     }
 
     /// Default init a column filling the parent

--- a/fltk/src/group.rs
+++ b/fltk/src/group.rs
@@ -673,6 +673,7 @@ pub struct Flex {
     setsized: Vec<Widget>,
 }
 
+// Code translated from https://github.com/osen/FL_Flex
 impl Flex {
     /// Create a new Flex widget
     pub fn new<T: Into<Option<&'static str>>>(x: i32, y: i32, w: i32, h: i32, label: T) -> Flex {

--- a/fltk/src/group.rs
+++ b/fltk/src/group.rs
@@ -565,6 +565,7 @@ impl DerefMut for HGrid {
 }
 
 /// A wrapper around a vertical pack, with `auto_layout`ing using the add method
+#[derive(Debug, Clone)]
 pub struct Column {
     p: Pack,
 }
@@ -610,6 +611,7 @@ impl DerefMut for Column {
 }
 
 /// A wrapper around a Horizontal pack, with `auto_layout`ing using the add method
+#[derive(Debug, Clone)]
 pub struct Row {
     p: Pack,
 }
@@ -678,6 +680,7 @@ pub enum FlexType {
     col.end();
     ```
 */
+#[derive(Debug, Clone)]
 pub struct Flex {
     grp: Group,
     dir: FlexType,

--- a/fltk/src/lib.rs
+++ b/fltk/src/lib.rs
@@ -205,8 +205,8 @@ The following are the features offered by the crate:
 
 Rust (version > 1.45), CMake (version > 3.0), Git and a C++11 compiler need to be installed and in your PATH for a crossplatform build from source. This crate also offers a bundled form of fltk on selected platforms, this can be enabled using the fltk-bundled feature flag (which requires curl and tar to download and unpack the bundled libraries).
 
-- Windows: No dependencies.
-- MacOS: No dependencies.
+- Windows: No external dependencies.
+- MacOS: No external dependencies.
 - Linux/BSD: X11 and OpenGL development headers need to be installed for development. The libraries themselves are available on linux distros with a graphical user interface.
 
 For Debian-based GUI distributions, that means running:


### PR DESCRIPTION
- Add overloads for `app::*_idle` and `app::*_timeout` which accept simple function pointers.
- Fix app::event_clicks() and add overload for event_clicks_num() for number of clicks.
- Add a Flex widget (which supports Flexbox layouts).
- Support `::new` and `::end` calls for Column and Row widgets.
- Support `::end` calls for VGrid and HGrid widgets.
- Update libc and FLTK.
