### PR TITLE
1.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 # Changelog
 
-
-## [1.1.8] - 2021-08-08
+## [1.1.9] - 2021-08-09
 - Add output::OutputType.
 - Add format_text example. Contributed by @mvasi90.
 - Fix some clippy lints.
@@ -9,6 +8,7 @@
 - Add image::RgbImage::convert().
 - Add ColorDepth::from_u8().
 - Add a widget_extends! macro for custom widgets, which basically implements Deref/DerefMut and adds convenience constructor and anchoring methods.
+- (Revert a breaking change introduced in 1.1.8)
 
 ## [1.1.7] - 2021-08-04
 - Fix invalid cast in TextBuffer::selection_position().

--- a/fltk-derive/Cargo.toml
+++ b/fltk-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk-derive"
-version = "1.1.8"
+version = "1.1.9"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 edition = "2018"
 description = "Rust bindings for the FLTK GUI library"

--- a/fltk-derive/src/widget.rs
+++ b/fltk-derive/src/widget.rs
@@ -35,19 +35,10 @@ pub fn impl_widget_base_trait(ast: &DeriveInput) -> TokenStream {
             }
         }
 
-        impl #name {
-            /// Creates a new widget, takes an x, y coordinates, as well as a width and height, plus a title
-            /// # Arguments
-            /// * `x` - The x coordinate in the screen
-            /// * `y` - The y coordinate in the screen
-            /// * `width` - The width of the widget
-            /// * `heigth` - The height of the widget
-            /// * `title` - The title or label of the widget
-            /// The title is expected to be a static str or None.
-            /// To use dynamic strings use `with_label(self, &str)` or `set_label(&mut self, &str)`
-            /// labels support special symbols preceded by an `@` [sign](https://www.fltk.org/doc-1.3/symbols.png).
-            /// and for the [associated formatting](https://www.fltk.org/doc-1.3/common.html).
-            pub fn new<T: Into<Option<&'static str>>>(x: i32, y: i32, width: i32, height: i32, title: T) -> #name {
+        crate::widget_extends!(#name);
+
+        unsafe impl WidgetBase for #name {
+            fn new<T: Into<Option<&'static str>>>(x: i32, y: i32, width: i32, height: i32, title: T) -> #name {
                 let temp = if let Some(title) = title.into() {
                     CString::safe_new(title).into_raw()
                 } else {
@@ -73,11 +64,7 @@ pub fn impl_widget_base_trait(ast: &DeriveInput) -> TokenStream {
                     }
                 }
             }
-        }
 
-        crate::widget_extends!(#name);
-
-        unsafe impl WidgetBase for #name {
             fn delete(mut wid: Self) {
                 assert!(!wid.was_deleted());
                 unsafe {

--- a/fltk/Cargo.toml
+++ b/fltk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk"
-version = "1.1.8"
+version = "1.1.9"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 edition = "2018"
 description = "Rust bindings for the FLTK GUI library"
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 
 [dependencies]
 fltk-sys = { path = "../fltk-sys", version = "=1.1.8" }
-fltk-derive = { path = "../fltk-derive", version = "=1.1.8" }
+fltk-derive = { path = "../fltk-derive", version = "=1.1.9" }
 lazy_static = "^1.4.0"
 bitflags = "^1.2.1"
 raw-window-handle = "^0.3.3"

--- a/fltk/src/prelude.rs
+++ b/fltk/src/prelude.rs
@@ -520,6 +520,18 @@ pub unsafe trait WidgetExt {
 
 /// Defines the extended methods implemented by all widgets
 pub unsafe trait WidgetBase: WidgetExt {
+    /// Creates a new widget, takes an x, y coordinates, as well as a width and height, plus a title
+    /// # Arguments
+    /// * `x` - The x coordinate in the screen
+    /// * `y` - The y coordinate in the screen
+    /// * `width` - The width of the widget
+    /// * `heigth` - The height of the widget
+    /// * `title` - The title or label of the widget
+    /// The title is expected to be a static str or None.
+    /// To use dynamic strings use `with_label(self, &str)` or `set_label(&mut self, &str)`
+    /// labels support special symbols preceded by an `@` [sign](https://www.fltk.org/doc-1.3/symbols.png).
+    /// and for the [associated formatting](https://www.fltk.org/doc-1.3/common.html).
+    fn new<T: Into<Option<&'static str>>>(x: i32, y: i32, width: i32, height: i32, title: T) -> Self;
     /// Deletes widgets and their children.
     fn delete(wid: Self)
     where


### PR DESCRIPTION
- Add output::OutputType.
- Add format_text example. Contributed by @mvasi90.
- Fix some clippy lints.
- Add Font::get_name().
- Add image::RgbImage::convert().
- Add ColorDepth::from_u8().
- Add a widget_extends! macro for custom widgets, which basically implements Deref/DerefMut and adds convenience constructor and anchoring methods.
- (Revert a breaking change introduced in 1.1.8)