### PR TITLE
1.1.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [1.1.9] - 2021-08-09
+## [1.1.10] - 2021-08-09
 - Add output::OutputType.
 - Add format_text example. Contributed by @mvasi90.
 - Fix some clippy lints.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,7 +3,6 @@
 - Remove draw::scale_x() in favor of scale(). 
 - Return Option String for WidgetExt::label(). 
 - Use i32 for app::set_font_size(). 
-- Enable adding a backend (graphics driver) through Rust. 
 - Export app submodules. 
 - Remove WidgetExt::width() and height() in favor of w() & h(). 
 - Add an fltk-extras crate to the current workspace consolidating fltk-theme, fltk-flex, fltk-calendar, fl2rust and fltk-fluid when they've matured enough, these can be individually enabled using feature flags.  

--- a/fltk-derive/Cargo.toml
+++ b/fltk-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk-derive"
-version = "1.1.9"
+version = "1.1.10"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 edition = "2018"
 description = "Rust bindings for the FLTK GUI library"

--- a/fltk/Cargo.toml
+++ b/fltk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk"
-version = "1.1.9"
+version = "1.1.10"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 edition = "2018"
 description = "Rust bindings for the FLTK GUI library"
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 
 [dependencies]
 fltk-sys = { path = "../fltk-sys", version = "=1.1.8" }
-fltk-derive = { path = "../fltk-derive", version = "=1.1.9" }
+fltk-derive = { path = "../fltk-derive", version = "=1.1.10" }
 lazy_static = "^1.4.0"
 bitflags = "^1.2.1"
 raw-window-handle = "^0.3.3"

--- a/fltk/examples/tabs.rs
+++ b/fltk/examples/tabs.rs
@@ -5,7 +5,7 @@ use fltk::{
     input::Input,
     menu::{Choice, MenuButton},
     output::Output,
-    prelude::{GroupExt, MenuExt, WidgetExt, WindowExt},
+    prelude::{GroupExt, MenuExt, WidgetBase, WidgetExt, WindowExt},
     window::Window,
 };
 

--- a/fltk/src/prelude.rs
+++ b/fltk/src/prelude.rs
@@ -103,7 +103,6 @@ pub trait WidgetType {
     fn from_i32(val: i32) -> Self;
 }
 
-
 /// Defines a set of convenience functions for constructing and anchoring custom widgets.
 /// Usage: fltk::widget_extends!(CustomWidget, BaseWidget, member);
 /// It basically implements Deref and DerefMut on the custom widget, and adds the aforementioned methods.
@@ -300,6 +299,58 @@ macro_rules! widget_extends {
 
 /// Defines the methods implemented by all widgets
 pub unsafe trait WidgetExt {
+    /// Initialize to a position x, y
+    fn with_pos(self, x: i32, y: i32) -> Self
+    where
+        Self: Sized;
+    /// Initialize to size width, height
+    fn with_size(self, width: i32, height: i32) -> Self
+    where
+        Self: Sized;
+    /// Initialize with a label
+    fn with_label(self, title: &str) -> Self
+    where
+        Self: Sized;
+    /// Initialize with alignment
+    fn with_align(self, align: crate::enums::Align) -> Self
+    where
+        Self: Sized;
+    /// Initialize with type
+    fn with_type<T: WidgetType>(self, typ: T) -> Self
+    where
+        Self: Sized;
+    /// Initialize at bottom of another widget
+    fn below_of<W: WidgetExt>(self, wid: &W, padding: i32) -> Self
+    where
+        Self: Sized;
+    /// Initialize above of another widget
+    fn above_of<W: WidgetExt>(self, wid: &W, padding: i32) -> Self
+    where
+        Self: Sized;
+    /// Initialize right of another widget
+    fn right_of<W: WidgetExt>(self, wid: &W, padding: i32) -> Self
+    where
+        Self: Sized;
+    /// Initialize left of another widget
+    fn left_of<W: WidgetExt>(self, wid: &W, padding: i32) -> Self
+    where
+        Self: Sized;
+    /// Initialize center of another widget
+    fn center_of<W: WidgetExt>(self, w: &W) -> Self
+    where
+        Self: Sized;
+    /// Initialize center of parent
+    fn center_of_parent(self) -> Self
+    where
+        Self: Sized;
+    /// Initialize to the size of another widget
+    fn size_of<W: WidgetExt>(self, w: &W) -> Self
+    where
+        Self: Sized;
+    /// Initialize to the size of the parent
+    fn size_of_parent(self) -> Self
+    where
+        Self: Sized;
     /// Set to position x, y
     fn set_pos(&mut self, x: i32, y: i32);
     /// Set to dimensions width and height
@@ -531,7 +582,13 @@ pub unsafe trait WidgetBase: WidgetExt {
     /// To use dynamic strings use `with_label(self, &str)` or `set_label(&mut self, &str)`
     /// labels support special symbols preceded by an `@` [sign](https://www.fltk.org/doc-1.3/symbols.png).
     /// and for the [associated formatting](https://www.fltk.org/doc-1.3/common.html).
-    fn new<T: Into<Option<&'static str>>>(x: i32, y: i32, width: i32, height: i32, title: T) -> Self;
+    fn new<T: Into<Option<&'static str>>>(
+        x: i32,
+        y: i32,
+        width: i32,
+        height: i32,
+        title: T,
+    ) -> Self;
     /// Deletes widgets and their children.
     fn delete(wid: Self)
     where


### PR DESCRIPTION
- Add output::OutputType.
- Add format_text example. Contributed by @mvasi90.
- Fix some clippy lints.
- Add Font::get_name().
- Add image::RgbImage::convert().
- Add ColorDepth::from_u8().
- Add a widget_extends! macro for custom widgets, which basically implements Deref/DerefMut and adds convenience constructor and anchoring methods.
- (Revert a breaking change introduced in 1.1.8)