### PR TITLE
Align scrollbartype with fltk

### DIFF
--- a/fltk/src/valuator.rs
+++ b/fltk/src/valuator.rs
@@ -215,18 +215,20 @@ impl Scrollbar {
 #[repr(i32)]
 #[derive(WidgetType, Debug, Copy, Clone, PartialEq)]
 pub enum ScrollbarType {
-    /// Vertical scrollbar
-    Vertical = 0,
-    /// Horizontal scrollbar
+    /// Only a horizontal scrollbar
     Horizontal = 1,
-    /// Vertical fill scrollbar
-    VerticalFill = 2,
-    /// Horizontal fill scrollbar
-    HorizontalFill = 3,
-    /// Vertical nice scrollbar
-    VerticalNice = 4,
-    /// Horizontal nice scrollbar
-    HorizontalNice = 5,
+    /// Only a vertical scrollbar
+    Vertical = 2,
+    /// The default is both scrollbars
+    Both = 3,
+    ///
+    AlwaysOn = 4,
+    /// Horizontal scrollbar always on, vertical always off
+    HorizontalAlways = 5,
+    /// Vertical scrollbar always on, horizontal always off
+    VerticalAlways = 6,
+    /// Both always on
+    BothAlways = 7,
 }
 
 /// Creates a roller widget

--- a/fltk/src/valuator.rs
+++ b/fltk/src/valuator.rs
@@ -215,6 +215,8 @@ impl Scrollbar {
 #[repr(i32)]
 #[derive(WidgetType, Debug, Copy, Clone, PartialEq)]
 pub enum ScrollbarType {
+    /// No scrollbars
+    None = 0,
     /// Only a horizontal scrollbar
     Horizontal = 1,
     /// Only a vertical scrollbar


### PR DESCRIPTION
The fltk enum for scroll bar types and the rust variant do not correspond, leading to confusing behavior of the scroll bar.

```cpp
  enum { // values for type()
    HORIZONTAL = 1,
    VERTICAL = 2,
    BOTH = 3,
    ALWAYS_ON = 4,
    HORIZONTAL_ALWAYS = 5,
    VERTICAL_ALWAYS = 6,
    BOTH_ALWAYS = 7
  };
```
https://github.com/fltk/fltk/blob/33cf312a73247ce6036e94ebe06d18da436dfe7e/FL/Fl_Scroll.H#L150-L158

In addition add a new variant (`None`) for disabling scrollbars which is not explicit in fltk enum but needs to be in Rust. It is however documented as such: https://github.com/fltk/fltk/blob/33cf312a73247ce6036e94ebe06d18da436dfe7e/FL/Fl_Scroll.H#L47