### PR TITLE
1.1.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Changelog
 
 
-## [1.1.14] - 2021-08-31
+## [1.1.15] - 2021-08-31
 - Pull FLTK tooltip fix for issue #797.
 - Fix `fn WidgetExt::callback() -> Option<Box<dyn FnMut()>>` (callback getter) to only work for FLTK types with default callbacks.
 - Properly export the widget_extends macro.
+- Fix undefined symbol on macos.
 
 ## [1.1.13] - 2021-08-27
 - Check for ImageExt::count() when calling ImageExt::to_rgb().

--- a/fltk-derive/Cargo.toml
+++ b/fltk-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk-derive"
-version = "1.1.14"
+version = "1.1.15"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 edition = "2018"
 description = "Rust bindings for the FLTK GUI library"

--- a/fltk-derive/src/window.rs
+++ b/fltk-derive/src/window.rs
@@ -103,9 +103,9 @@ pub fn impl_window_trait(ast: &DeriveInput) -> TokenStream {
                 {
                     let raw = self.raw_handle();
                     extern "C" {
-                        pub fn my_getContentView(xid: *mut raw::c_void) -> *mut raw::c_void;
+                        pub fn my_getContetView(xid: *mut raw::c_void) -> *mut raw::c_void;
                     }
-                    let cv = unsafe { my_getContentView(raw) };
+                    let cv = unsafe { my_getContetView(raw) };
                     return RawWindowHandle::MacOS(macos::MacOSHandle {
                         ns_window: raw,
                         ns_view: cv as _,

--- a/fltk/Cargo.toml
+++ b/fltk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk"
-version = "1.1.14"
+version = "1.1.15"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 edition = "2018"
 description = "Rust bindings for the FLTK GUI library"
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 
 [dependencies]
 fltk-sys = { path = "../fltk-sys", version = "=1.1.14" }
-fltk-derive = { path = "../fltk-derive", version = "=1.1.14" }
+fltk-derive = { path = "../fltk-derive", version = "=1.1.15" }
 bitflags = "^1.3"
 raw-window-handle = { version = "^0.3.3", optional = true }
 


### PR DESCRIPTION
- Pull FLTK tooltip fix for issue #797.
- Fix `fn WidgetExt::callback() -> Option<Box<dyn FnMut()>>` (callback getter) to only work for FLTK types with default callbacks.
- Properly export the widget_extends macro.
- Fix undefined symbol on macos.
