### PR TITLE
1.1.19

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Download deps
       run: |
          if [ "$RUNNER_OS" == "Linux" ]; then
-          sudo apt-get update && sudo apt-get install -y libpango1.0-dev libx11-dev libxext-dev libxft-dev libxinerama-dev libxcursor-dev libxrender-dev libxfixes-dev libpng-dev
+          sudo apt-get update && sudo apt-get install -y libpango1.0-dev libx11-dev libxext-dev libxft-dev libxinerama-dev libxcursor-dev libxrender-dev libxfixes-dev libpng-dev libgl1-mesa-dev libglu1-mesa-dev
          fi
       shell: bash
     - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,16 @@
 # Changelog
 
 
-## [1.1.19] - Unreleased
-- Using fltk-bundled automatically enables glwindow. Note, other bundles can be used via the CFLTK_BUNDLE_DIR or CFLTK_BUNDLE_URL env variables.
+## [1.1.19] - 2021-09-18
+- Fix doc comments about FileDialog and NativeFileChooser.
+- Using fltk-bundled automatically enables glwindow. Note, other user-built bundles can be cached and used via the CFLTK_BUNDLE_DIR or CFLTK_BUNDLE_URL env variables.
+- Remove unnecessary references to use-ninja in the README and main docs since it will be used if found.
+- Update ROADMAP.
 
 ## [1.1.18] - 2021-09-15
 - Open display for certain draw functions when appropriate.
 - Add TextBuffer::search_forward(), search_backward(), find_char_forward() and find_char_backward().
 - Add DisplayExt::unset_highlight_data() convenience method.
-- Also deploy fltk_gl in the fltk-bundle, user code will still need to call enable-glwindow for it to be linked into the resulting binary if needed.
 - Update FLTK to pull nanosvg fixes.
 
 ## [1.1.17] - 2021-09-10

--- a/README.md
+++ b/README.md
@@ -56,8 +56,6 @@ fltk = { version = "^1.1", features = ["fltk-bundled"] }
 
 The library is automatically built and statically linked to your binary.
 
-For faster builds you can enable ninja builds for the C++ source using the "use-ninja" feature.
-
 An example hello world application:
 
 ```rust
@@ -216,11 +214,11 @@ For default application colors, fltk-rs provides `app::background()`, `app::back
 
 ## Dependencies
 
-Rust (version > 1.45), CMake (version > 3.0), Git and a C++11 compiler need to be installed and in your PATH for a crossplatform build from source. This crate also offers a bundled form of fltk on selected platforms (win 10 x64, macos 10.15 x64, linux x64), this can be enabled using the `fltk-bundled` feature-flag (which requires curl and tar to download and unpack the bundled libraries).
+Rust (version > 1.45), CMake (version > 3.0), Git and a C++11 compiler need to be installed and in your PATH for a crossplatform build from source. [Ninja](https://github.com/ninja-build/ninja) is recommended, but not required, and will be used if found. This crate also offers a bundled form of fltk on selected x86_64 platforms (Windows (msvc and gnu), MacOS, Linux), this can be enabled using the fltk-bundled feature flag as mentioned in the usage section (this requires curl and tar to download and unpack the bundled libraries).
 
 - Windows: No external dependencies.
 - MacOS: No external dependencies.
-- Linux/BSD: X11 and OpenGL development headers need to be installed for development. The libraries themselves are available on linux distros with a graphical user interface.
+- Linux/BSD: X11 and OpenGL development headers need to be installed for development. The libraries themselves are normally available on linux/bsd distros with a graphical user interface.
 
 For Debian-based GUI distributions, that means running:
 ```
@@ -249,7 +247,6 @@ The following are the features offered by the crate:
 - no-pango: Build without pango support on Linux/BSD, if rtl/cjk font support is not needed.
 - fltk-bundled: Support for bundled versions of cfltk and fltk on selected platforms (requires curl and tar)
 - enable-glwindow: Support for drawing using OpenGL functions.
-- use-ninja:  If you have ninja build installed, it builds faster than make or VS
 - system-libpng: Uses the system libpng
 - system-libjpeg: Uses the system libjpeg
 - system-zlib: Uses the system zlib

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,9 +1,11 @@
 # Roadmap for version 2 (ETA mid 2022). 
 
 - Remove draw::scale_x() in favor of scale(). 
-- Return Option String for WidgetExt::label(). 
+- Probably return Option String for WidgetExt::label(). 
 - Use i32 for app::set_font_size(). 
 - Export app submodules. 
 - Remove WidgetExt::width() and height() in favor of w() & h(). 
 - Add an fltk-extras crate to the current workspace consolidating fltk-theme, fltk-flex, fltk-calendar, fl2rust and fltk-fluid when they've matured enough, these can be individually enabled using feature flags.
 - DisplayExt::set_hightlight_data() doesn't need to take an optional TextBuffer.
+- Deprecate app::background() etc in favor of app::set_background_color() etc.
+- Rename WidgetExt::into_widget() to as_widget() and GroupExt::into_group() to as_group() to conform to Rust's self convention.

--- a/fltk/src/dialog.rs
+++ b/fltk/src/dialog.rs
@@ -22,13 +22,13 @@ pub enum ColorMode {
     Hsv = 3,
 }
 
-/// Creates a file button
+/// FLTK's NativeFileChooser
 #[derive(Debug)]
 pub struct FileDialog {
     inner: *mut Fl_Native_File_Chooser,
 }
 
-/// Re-alias `FileDialog` to `NativeFileChooser` (`Fl_Native_File_Chooser`)
+/// FLTK's NativeFileChooser
 pub type NativeFileChooser = FileDialog;
 
 /// Defines the type of dialog, which can be changed dynamically using the `set_type()` method

--- a/fltk/src/lib.rs
+++ b/fltk/src/lib.rs
@@ -58,8 +58,6 @@ fltk = { version = "^1.1", features = ["fltk-bundled"] }
 
 The library is automatically built and statically linked to your binary.
 
-For faster builds you can enable ninja builds for the C++ source using the "use-ninja" feature.
-
 An example hello world application:
 
 ```rust,no_run
@@ -219,11 +217,11 @@ For default application colors, fltk-rs provides `app::background()`, `app::back
 
 ## Dependencies
 
-Rust (version > 1.45), CMake (version > 3.0), Git and a C++11 compiler need to be installed and in your PATH for a crossplatform build from source. This crate also offers a bundled form of fltk on selected platforms, this can be enabled using the fltk-bundled feature flag (which requires curl and tar to download and unpack the bundled libraries).
+Rust (version > 1.45), CMake (version > 3.0), Git and a C++11 compiler need to be installed and in your PATH for a crossplatform build from source. [Ninja](https://github.com/ninja-build/ninja) is recommended, but not required, and will be used if found. This crate also offers a bundled form of fltk on selected x86_64 platforms (Windows (msvc and gnu), MacOS, Linux), this can be enabled using the fltk-bundled feature flag as mentioned in the usage section (this requires curl and tar to download and unpack the bundled libraries).
 
 - Windows: No external dependencies.
 - MacOS: No external dependencies.
-- Linux/BSD: X11 and OpenGL development headers need to be installed for development. The libraries themselves are available on linux distros with a graphical user interface.
+- Linux/BSD: X11 and OpenGL development headers need to be installed for development. The libraries themselves are normally available on linux distros with a graphical user interface.
 
 For Debian-based GUI distributions, that means running:
 ```ignore
@@ -252,7 +250,6 @@ The following are the features offered by the crate:
 - fltk-bundled: Support for bundled versions of cfltk and fltk on selected platforms (requires curl and tar)
 - no-pango: Build without pango support on Linux/BSD.
 - enable-glwindow: Support for drawing using OpenGL functions.
-- use-ninja:  If you have ninja build installed, it builds faster than make or VS
 - system-libpng: Uses the system libpng
 - system-libjpeg: Uses the system libjpeg
 - system-zlib: Uses the system zlib
@@ -263,9 +260,9 @@ please check the [FAQ](https://github.com/fltk-rs/fltk-rs/blob/master/FAQ.md) pa
 */
 
 #![allow(non_upper_case_globals)]
+#![allow(clippy::needless_doctest_main)]
 #![warn(missing_docs)]
 #![warn(broken_intra_doc_links)]
-#![allow(clippy::needless_doctest_main)]
 
 /// Application related methods and functions
 pub mod app;


### PR DESCRIPTION
- Fix doc comments about FileDialog and NativeFileChooser.
- Using fltk-bundled automatically enables glwindow. Note, other user-built bundles can be cached and used via the CFLTK_BUNDLE_DIR or CFLTK_BUNDLE_URL env variables.
- Remove unnecessary references to use-ninja in the README and main docs since it will be used if found.
- Update ROADMAP.
