### PR TITLE
1.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,9 @@
 # Changelog
 
 ## [1.2.3] - 2021-09-24
+- Add a new group::Flex widget wrapping [Fl_Flex](https://github.com/osen/FL_Flex).
 - Use fork of FL_Flex to avoid patching, then linking libstd++.
 - Add Flex's margin and pad properties getter and setter.
-
-## [1.2.2] - 2021-09-23
-- Add a new group::Flex widget wrapping [Fl_Flex](https://github.com/osen/FL_Flex).
 - Add WidgetBase::resize_callback().
 - Add WidgetBase::default_fill() to construct a widget with the size of its parent.
 - Improve some docs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## [1.2.3] - 2021-09-24
-- Use fork of FL_Flex to avoid patching.
+- Use fork of FL_Flex to avoid patching, then linking libstd++.
 - Add Flex's margin and pad properties getter and setter.
 
 ## [1.2.2] - 2021-09-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-## [1.2.0] - 2021-09-23
+## [1.2.1] - 2021-09-23
 - Add a new group::Flex widget wrapping [Fl_Flex](https://github.com/osen/FL_Flex).
 - Add WidgetBase::resize_callback().
 - Add WidgetBase::default_fill() to construct a widget with the size of its parent.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 # Changelog
 
 
-## [1.2.1] - 2021-09-23
+## [1.2.2] - 2021-09-23
 - Add a new group::Flex widget wrapping [Fl_Flex](https://github.com/osen/FL_Flex).
 - Add WidgetBase::resize_callback().
 - Add WidgetBase::default_fill() to construct a widget with the size of its parent.
 - Improve some docs.
 - Derive Default for Column, Row and Grid widgets.
+- Fix cargo doc build issue on docs.rs.
 
 ## [1.1.19] - 2021-09-18
 - Fix doc comments about FileDialog and NativeFileChooser.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [1.2.3] - 2021-09-24
+- Use fork of FL_Flex to avoid patching.
+- Add Flex's margin and pad properties getter and setter.
 
 ## [1.2.2] - 2021-09-23
 - Add a new group::Flex widget wrapping [Fl_Flex](https://github.com/osen/FL_Flex).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Add a new group::Flex widget wrapping [Fl_Flex](https://github.com/osen/FL_Flex).
 - Use fork of FL_Flex to avoid patching, then linking libstd++.
 - Add Flex's margin and pad properties getter and setter.
+- Overload Flex::add to recalculate layout.
 - Add WidgetBase::resize_callback().
 - Add WidgetBase::default_fill() to construct a widget with the size of its parent.
 - Improve some docs.

--- a/README.md
+++ b/README.md
@@ -474,6 +474,7 @@ Various advanced examples can also be found [here](https://github.com/wyhinton/F
 ## Tutorials
 
 - [Basics](https://www.youtube.com/watch?v=ygP4egJtmzw)
+- [New basics](https://youtu.be/S1NSsHZs6hI) (Uses fltk post 1.0)
 - [User input](https://youtu.be/rIq2O4vg9fQ)
 - [Client-side web todo app](https://youtu.be/tdfFXi4-Yrw)
 - [Create a media player using the vlc crate](https://youtu.be/enxqU3bhCEs)

--- a/fltk-sys/Cargo.toml
+++ b/fltk-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk-sys"
-version = "1.2.1"
+version = "1.2.3"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 build = "build/main.rs"
 edition = "2018"

--- a/fltk-sys/build/link.rs
+++ b/fltk-sys/build/link.rs
@@ -86,7 +86,6 @@ pub fn link(target_os: &str, target_triple: &str, out_dir: &Path) {
                 println!("cargo:rustc-link-lib=framework=Carbon");
                 println!("cargo:rustc-link-lib=framework=Cocoa");
                 println!("cargo:rustc-link-lib=framework=ApplicationServices");
-                println!("cargo:rustc-link-lib=c++");
             }
             "windows" => {
                 println!("cargo:rustc-link-lib=dylib=ws2_32");
@@ -104,9 +103,6 @@ pub fn link(target_os: &str, target_triple: &str, out_dir: &Path) {
                 println!("cargo:rustc-link-lib=dylib=odbc32");
                 if !cfg!(feature = "no-gdiplus") {
                     println!("cargo:rustc-link-lib=dylib=gdiplus");
-                }
-                if cfg!(target_env = "gnu") {
-                    println!("cargo:rustc-link-lib=dylib=std++");
                 }
             }
             "android" => {
@@ -128,7 +124,6 @@ pub fn link(target_os: &str, target_triple: &str, out_dir: &Path) {
                 println!("cargo:rustc-link-lib=dylib=Xfixes");
                 println!("cargo:rustc-link-lib=dylib=Xft");
                 println!("cargo:rustc-link-lib=dylib=fontconfig");
-                println!("cargo:rustc-link-lib=dylib=stdc++");
                 if !cfg!(feature = "no-pango") {
                     println!("cargo:rustc-link-lib=dylib=pango-1.0");
                     println!("cargo:rustc-link-lib=dylib=pangoxft-1.0");

--- a/fltk-sys/build/source.rs
+++ b/fltk-sys/build/source.rs
@@ -64,12 +64,6 @@ pub fn build(manifest_dir: &Path, target_triple: &str, out_dir: &Path) {
             .expect("Git is needed to retrieve the fltk source files!");
     }
 
-    Command::new("git")
-        .args(&["apply", "../flex.patch"])
-        .current_dir(manifest_dir.join("cfltk").join("FL_FLex"))
-        .status()
-        .expect("Git is needed to retrieve the fltk source files!");
-
     if !target_triple.contains("android") {
         let mut dst = cmake::Config::new("cfltk");
 
@@ -188,10 +182,4 @@ pub fn build(manifest_dir: &Path, target_triple: &str, out_dir: &Path) {
             .status()
             .expect("Git is needed to retrieve the fltk source files!");
     }
-
-    Command::new("git")
-        .args(&["reset", "--hard"])
-        .current_dir(manifest_dir.join("cfltk").join("FL_FLex"))
-        .status()
-        .expect("Git is needed to retrieve the fltk source files!");
 }

--- a/fltk-sys/src/group.rs
+++ b/fltk-sys/src/group.rs
@@ -2924,6 +2924,18 @@ extern "C" {
     pub fn Fl_Flex_set_debug(val: ::std::os::raw::c_int);
 }
 extern "C" {
+    pub fn Fl_Flex_set_margin(self_: *mut Fl_Flex, m: ::std::os::raw::c_int);
+}
+extern "C" {
+    pub fn Fl_Flex_margin(self_: *const Fl_Flex) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn Fl_Flex_set_pad(self_: *mut Fl_Flex, p: ::std::os::raw::c_int);
+}
+extern "C" {
+    pub fn Fl_Flex_pad(self_: *const Fl_Flex) -> ::std::os::raw::c_int;
+}
+extern "C" {
     pub fn Fl_Flex_begin(self_: *mut Fl_Flex);
 }
 extern "C" {

--- a/fltk-sys/src/group.rs
+++ b/fltk-sys/src/group.rs
@@ -2921,7 +2921,7 @@ extern "C" {
     pub fn Fl_Flex_set_size(self_: *mut Fl_Flex, w: *mut Fl_Widget, size: ::std::os::raw::c_int);
 }
 extern "C" {
-    pub fn Fl_Flex_set_debug(self_: *mut Fl_Flex, val: ::std::os::raw::c_int);
+    pub fn Fl_Flex_set_debug(val: ::std::os::raw::c_int);
 }
 extern "C" {
     pub fn Fl_Flex_begin(self_: *mut Fl_Flex);

--- a/fltk/Cargo.toml
+++ b/fltk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk"
-version = "1.2.2"
+version = "1.2.3"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 edition = "2018"
 description = "Rust bindings for the FLTK GUI library"
@@ -17,7 +17,7 @@ name = "fltk"
 path = "src/lib.rs"
 
 [dependencies]
-fltk-sys = { path = "../fltk-sys", version = "=1.2.1" }
+fltk-sys = { path = "../fltk-sys", version = "=1.2.3" }
 fltk-derive = { path = "../fltk-derive", version = "=1.2.0" }
 bitflags = "^1.3"
 raw-window-handle = { version = "^0.3.3", optional = true }

--- a/fltk/Cargo.toml
+++ b/fltk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk"
-version = "1.2.1"
+version = "1.2.2"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 edition = "2018"
 description = "Rust bindings for the FLTK GUI library"
@@ -39,7 +39,7 @@ legacy-opengl = ["fltk-sys/legacy-opengl"] # (Experimental) Support of Lagacy Op
 single-threaded = ["fltk-sys/single-threaded"] # (Experimental) Disable multithreading support when linking X11 libs non-mt x11 libs.
 
 [package.metadata.docs.rs]
-features = ["enable-glwindow"]
+features = ["fltk-bundled"]
 
 [[test]]
 name = "app_handle"

--- a/fltk/Cargo.toml
+++ b/fltk/Cargo.toml
@@ -39,7 +39,7 @@ legacy-opengl = ["fltk-sys/legacy-opengl"] # (Experimental) Support of Lagacy Op
 single-threaded = ["fltk-sys/single-threaded"] # (Experimental) Disable multithreading support when linking X11 libs non-mt x11 libs.
 
 [package.metadata.docs.rs]
-features = ["fltk-bundled"]
+features = ["enable-glwindow"]
 
 [[test]]
 name = "app_handle"

--- a/fltk/src/group.rs
+++ b/fltk/src/group.rs
@@ -387,8 +387,8 @@ impl Flex {
     }
 
     /// Debug the flex layout
-    pub fn debug(&mut self, flag: bool) {
-        unsafe { Fl_Flex_set_debug(self.inner, flag as _) }
+    pub fn debug(flag: bool) {
+        unsafe { Fl_Flex_set_debug(flag as _) }
     }
 
     /// Set the type to be a column

--- a/fltk/src/group.rs
+++ b/fltk/src/group.rs
@@ -407,6 +407,34 @@ impl Flex {
     pub fn recalc(&mut self) {
         self.end();
     }
+
+    /// Set the margin
+    pub fn set_margin(&mut self, m: i32) {
+        unsafe {
+            Fl_Flex_set_margin(self.inner, m)
+        }
+    }
+
+    /// Get the margin
+    pub fn margin(&self) -> i32 {
+        unsafe {
+            Fl_Flex_margin(self.inner)
+        }
+    }
+
+    /// Set the padding
+    pub fn set_pad(&mut self, p: i32) {
+        unsafe {
+            Fl_Flex_set_pad(self.inner, p)
+        }
+    }
+
+    /// Get the padding
+    pub fn pad(&self) -> i32 {
+        unsafe {
+            Fl_Flex_pad(self.inner)
+        }
+    }
 }
 
 /**

--- a/fltk/src/group.rs
+++ b/fltk/src/group.rs
@@ -381,6 +381,12 @@ pub struct Flex {
 }
 
 impl Flex {
+    /// Add a widget to the Flex box
+    pub fn add<W: WidgetExt>(&mut self, widget: &W) {
+        <Self as GroupExt>::add(self, widget);
+        self.recalc();
+    }
+    
     /// Set the size of the widget
     pub fn set_size<W: WidgetExt>(&mut self, w: &mut W, size: i32) {
         unsafe { Fl_Flex_set_size(self.inner, w.as_widget_ptr() as _, size) }


### PR DESCRIPTION
- Add a new group::Flex widget wrapping [Fl_Flex](https://github.com/osen/FL_Flex).
- Use fork of FL_Flex to avoid patching, then linking libstd++.
- Add Flex's margin and pad properties getter and setter.
- Overload Flex::add to recalculate layout.
- Add WidgetBase::resize_callback().
- Add WidgetBase::default_fill() to construct a widget with the size of its parent.
- Improve some docs.
- Derive Default for Column, Row and Grid widgets.
- Fix cargo doc build issue on docs.rs.