### PR TITLE
1.2.9

### DIFF
--- a/fltk-sys/Cargo.toml
+++ b/fltk-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk-sys"
-version = "1.2.8"
+version = "1.2.9"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 build = "build/main.rs"
 edition = "2018"

--- a/fltk/Cargo.toml
+++ b/fltk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk"
-version = "1.2.8"
+version = "1.2.9"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 edition = "2018"
 description = "Rust bindings for the FLTK GUI library"
@@ -17,7 +17,7 @@ name = "fltk"
 path = "src/lib.rs"
 
 [dependencies]
-fltk-sys = { path = "../fltk-sys", version = "=1.2.8" }
+fltk-sys = { path = "../fltk-sys", version = "=1.2.9" }
 bitflags = "^1.3.2"
 paste = "1"
 raw-window-handle = { version = "^0.3.3", optional = true }


### PR DESCRIPTION
- Fix image links in crates.io.
- Adds image::RgbScaling enum.
- Adds RgbImage::scaling_algorithm() and set_scaling_algorithm().
- Add ImageExt::to_rgb_image().
- Add RgbImage::from_pixmap().
- Assert image size in WindowExt::set_cursor_image().
- Scale returned RgbImage in ImageExt::to_rgb().
- Update FLTK.