### PR TITLE
Small fix for android build

### DIFF
--- a/fltk/src/window.rs
+++ b/fltk/src/window.rs
@@ -396,7 +396,7 @@ impl DoubleWindow {
                 }
                 my_winShow(self.raw_handle());
             }
-            #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+            #[cfg(not(any(target_os = "macos", target_os = "android", target_os = "windows")))]
             {
                 enum Display {}
                 extern "C" {
@@ -425,7 +425,7 @@ impl DoubleWindow {
                 }
                 my_winHide(self.raw_handle());
             }
-            #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+            #[cfg(not(any(target_os = "macos", target_os = "android", target_os = "windows")))]
             {
                 enum Display {}
                 extern "C" {


### PR DESCRIPTION
# Description
since XMapWindow and XUnmapWindow available on x11 only, i got error messages:
```bash
dell@Ar37-rs:~/playground/java/fltk-rs-android/app/src/main/cpp/app$ cargo build --target aarch64-linux-android
   Compiling fltk v1.2.14
error[E0308]: mismatched types
   --> /home/dell/.cargo/registry/src/github.com-1ecc6299db9ec823/fltk-1.2.14/src/window.rs:405:56
    |
405 |                 XMapWindow(crate::app::display() as _, self.raw_handle());
    |                                                        ^^^^^^^^^^^^^^^^^ expected `u64`, found *-ptr
    |
    = note:     expected type `u64`
            found raw pointer `*mut c_void`

error[E0308]: mismatched types
   --> /home/dell/.cargo/registry/src/github.com-1ecc6299db9ec823/fltk-1.2.14/src/window.rs:434:58
    |
434 |                 XUnmapWindow(crate::app::display() as _, self.raw_handle());
    |                                                          ^^^^^^^^^^^^^^^^^ expected `u64`, found *-ptr
    |
    = note:     expected type `u64`
            found raw pointer `*mut c_void`

For more information about this error, try `rustc --explain E0308`.
error: could not compile `fltk` due to 2 previous errors
```