### PR TITLE
1.2.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-## [1.2.14] - Unreleased
+## [1.2.14] - 2021-11-09
 - Mark Window::platform_hide() and platform_show() as safe.
 - Add WindowExt::wait_for_expose().
 - Fix div by zero in Flex orphaned space.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 
+## [1.2.15] - Unreleased
+- Fix android build (break introduced with version 1.2.11).
+
 ## [1.2.14] - 2021-11-09
 - Mark Window::platform_hide() and platform_show() as safe.
 - Add WindowExt::wait_for_expose().

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-## [1.2.15] - Unreleased
+## [1.2.15] - 2021-11-11
 - Fix android build (break introduced with version 1.2.11).
 
 ## [1.2.14] - 2021-11-09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ## [1.2.15] - 2021-11-11
 - Fix android build (break introduced with version 1.2.11).
+- Don't assert that window is shown with set_opacity.
 
 ## [1.2.14] - 2021-11-09
 - Mark Window::platform_hide() and platform_show() as safe.

--- a/fltk/Cargo.toml
+++ b/fltk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk"
-version = "1.2.14"
+version = "1.2.15"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 edition = "2018"
 description = "Rust bindings for the FLTK GUI library"

--- a/fltk/src/window.rs
+++ b/fltk/src/window.rs
@@ -339,15 +339,16 @@ impl DoubleWindow {
     /// ```
     pub fn set_opacity(&mut self, val: f64) {
         assert!(!self.was_deleted());
-        assert!(self.shown());
-        let val: u8 = if val > 1.0 {
-            255
-        } else if val < 0.0 {
-            0
-        } else {
-            (val * 255.0).round() as u8
-        };
-        unsafe { Fl_Double_Window_set_alpha(self.inner, val) }
+        if self.shown() {
+            let val: u8 = if val > 1.0 {
+                255
+            } else if val < 0.0 {
+                0
+            } else {
+                (val * 255.0).round() as u8
+            };
+            unsafe { Fl_Double_Window_set_alpha(self.inner, val) }
+        }
     }
 
     /// Returns the pixels per unit.


### PR DESCRIPTION
- Fix android build (break introduced with version 1.2.11).
- Don't assert that window is shown with set_opacity.
