### PR TITLE
1.2.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 
 ## [1.2.16] - Unreleased
+- Add WidgetExt::center_x() and center_y().
 - Allow scraping examples for docs.rs.
 - Expose WidgetExt::raw_user_data() and set_raw_user_data().
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-## [1.2.16] - Unreleased
+## [1.2.16] - 2021-11-15
 - Add WidgetExt::center_x() and center_y().
 - Allow scraping examples for docs.rs.
 - Add Fl_Flex::remove to C wrapper.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ## [1.2.16] - Unreleased
 - Add WidgetExt::center_x() and center_y().
 - Allow scraping examples for docs.rs.
+- Add Fl_Flex::remove to C wrapper.
 - Expose WidgetExt::raw_user_data() and set_raw_user_data().
 
 ## [1.2.15] - 2021-11-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 
+## [1.2.16] - Unreleased
+- Allow scraping examples for docs.rs.
+- Expose WidgetExt::raw_user_data() and set_raw_user_data().
+
 ## [1.2.15] - 2021-11-11
 - Fix android build (break introduced with version 1.2.11). Thanks @Ar37-rs. 
 - Don't assert that window is shown with set_opacity.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Allow scraping examples for docs.rs.
 - Add Fl_Flex::remove to C wrapper.
 - Expose WidgetExt::raw_user_data() and set_raw_user_data().
+- Pull fixes from FLTK.
 
 ## [1.2.15] - 2021-11-11
 - Fix android build (break introduced with version 1.2.11). Thanks @Ar37-rs. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 
 ## [1.2.15] - 2021-11-11
-- Fix android build (break introduced with version 1.2.11).
+- Fix android build (break introduced with version 1.2.11). Thanks @Ar37-rs. 
 - Don't assert that window is shown with set_opacity.
 
 ## [1.2.14] - 2021-11-09

--- a/fltk-sys/Cargo.toml
+++ b/fltk-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk-sys"
-version = "1.2.14"
+version = "1.2.16"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 build = "build/main.rs"
 edition = "2018"

--- a/fltk/Cargo.toml
+++ b/fltk/Cargo.toml
@@ -17,7 +17,7 @@ name = "fltk"
 path = "src/lib.rs"
 
 [dependencies]
-fltk-sys = { path = "../fltk-sys", version = "=1.2.14" }
+fltk-sys = { path = "../fltk-sys", version = "=1.2.16" }
 bitflags = "^1.3"
 paste = "1"
 raw-window-handle = { version = "^0.3", optional = true }

--- a/fltk/Cargo.toml
+++ b/fltk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk"
-version = "1.2.15"
+version = "1.2.16"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 edition = "2018"
 description = "Rust bindings for the FLTK GUI library"

--- a/fltk/Cargo.toml
+++ b/fltk/Cargo.toml
@@ -40,7 +40,7 @@ single-threaded = ["fltk-sys/single-threaded"] # (Experimental) Disable multithr
 
 [package.metadata.docs.rs]
 features = ["enable-glwindow"]
-# cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples=examples"]
+cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples=examples"]
 
 [[test]]
 name = "app_handle"

--- a/fltk/src/macros/widget.rs
+++ b/fltk/src/macros/widget.rs
@@ -133,6 +133,44 @@ macro_rules! impl_widget_ext {
                     self
                 }
 
+                /// Initialize center of another widget
+                fn center_x<W: $crate::prelude::WidgetExt>(mut self, w: &W) -> Self {
+                    assert!(!w.was_deleted());
+                    assert!(!self.was_deleted());
+                    debug_assert!(
+                        w.width() != 0 && w.height() != 0,
+                        "center_of requires the size of the widget to be known!"
+                    );
+                    let sw = self.width() as f64;
+                    let sh = self.height() as f64;
+                    let ww = w.width() as f64;
+                    let sx = (ww - sw) / 2.0;
+                    let sy = self.y();
+                    let wx = if w.as_window().is_some() { 0 } else { w.x() };
+                    self.resize(sx as i32 + wx, sy, sw as i32, sh as i32);
+                    self.redraw();
+                    self
+                }
+
+                /// Initialize center of another widget
+                fn center_y<W: $crate::prelude::WidgetExt>(mut self, w: &W) -> Self {
+                    assert!(!w.was_deleted());
+                    assert!(!self.was_deleted());
+                    debug_assert!(
+                        w.width() != 0 && w.height() != 0,
+                        "center_of requires the size of the widget to be known!"
+                    );
+                    let sw = self.width() as f64;
+                    let sh = self.height() as f64;
+                    let wh = w.height() as f64;
+                    let sx = self.x();
+                    let sy = (wh - sh) / 2.0;
+                    let wy = if w.as_window().is_some() { 0 } else { w.y() };
+                    self.resize(sx, sy as i32 + wy, sw as i32, sh as i32);
+                    self.redraw();
+                    self
+                }
+
                 fn center_of_parent(mut self) -> Self {
                     assert!(!self.was_deleted());
                     if let Some(w) = self.parent() {

--- a/fltk/src/macros/widget.rs
+++ b/fltk/src/macros/widget.rs
@@ -504,6 +504,14 @@ macro_rules! impl_widget_ext {
                     }
                 }
 
+                unsafe fn raw_user_data(&self) -> *mut std::os::raw::c_void {
+                    [<$flname _user_data>](self.inner)
+                }
+
+                unsafe fn set_raw_user_data(&mut self, data: *mut std::os::raw::c_void) {
+                    [<$flname _set_user_data>](self.inner, data)
+                }
+
                 fn take_focus(&mut self) -> Result<(), FltkError> {
                     assert!(!self.was_deleted());
                     unsafe {

--- a/fltk/src/prelude.rs
+++ b/fltk/src/prelude.rs
@@ -147,11 +147,11 @@ pub unsafe trait WidgetExt {
     fn center_of<W: WidgetExt>(self, w: &W) -> Self
     where
         Self: Sized;
-    /// Initialize center of another widget
+    /// Initialize center of another widget on the x axis
     fn center_x<W: WidgetExt>(self, w: &W) -> Self
     where
         Self: Sized;
-    /// Initialize center of another widget
+    /// Initialize center of another widget on the y axis
     fn center_y<W: WidgetExt>(self, w: &W) -> Self
     where
         Self: Sized;
@@ -346,12 +346,12 @@ pub unsafe trait WidgetExt {
     /// Can return multiple mutable references to the `user_data`
     unsafe fn user_data(&self) -> Option<Box<dyn FnMut()>>;
     #[doc(hidden)]
-    /// INTERNAL: Retakes ownership of the user callback data
+    /// INTERNAL: Get the raw user data of the widget
     /// # Safety
     /// Can return multiple mutable references to the `user_data`
     unsafe fn raw_user_data(&self) -> *mut std::os::raw::c_void;
     #[doc(hidden)]
-    /// INTERNAL: Retakes ownership of the user callback data
+    /// INTERNAL: Set the raw user data of the widget
     /// # Safety
     /// Can return multiple mutable references to the `user_data`
     unsafe fn set_raw_user_data(&mut self, data: *mut std::os::raw::c_void);
@@ -1519,7 +1519,7 @@ macro_rules! widget_extends {
                 self
             }
 
-            /// Initialize center of another widget
+            /// Initialize center of another widget on the x axis
             pub fn center_x<W: $crate::prelude::WidgetExt>(mut self, w: &W) -> Self {
                 assert!(!w.was_deleted());
                 assert!(!self.was_deleted());
@@ -1538,7 +1538,7 @@ macro_rules! widget_extends {
                 self
             }
 
-            /// Initialize center of another widget
+            /// Initialize center of another widget on the y axis
             pub fn center_y<W: $crate::prelude::WidgetExt>(mut self, w: &W) -> Self {
                 assert!(!w.was_deleted());
                 assert!(!self.was_deleted());

--- a/fltk/src/prelude.rs
+++ b/fltk/src/prelude.rs
@@ -332,10 +332,21 @@ pub unsafe trait WidgetExt {
     fn as_window(&self) -> Option<Box<dyn WindowExt>>;
     /// Return the widget as a group widget if it's a group widget
     fn as_group(&self) -> Option<crate::group::Group>;
+    #[doc(hidden)]
     /// INTERNAL: Retakes ownership of the user callback data
     /// # Safety
     /// Can return multiple mutable references to the `user_data`
     unsafe fn user_data(&self) -> Option<Box<dyn FnMut()>>;
+    #[doc(hidden)]
+    /// INTERNAL: Retakes ownership of the user callback data
+    /// # Safety
+    /// Can return multiple mutable references to the `user_data`
+    unsafe fn raw_user_data(&self) -> *mut std::os::raw::c_void;
+    #[doc(hidden)]
+    /// INTERNAL: Retakes ownership of the user callback data
+    /// # Safety
+    /// Can return multiple mutable references to the `user_data`
+    unsafe fn set_raw_user_data(&mut self, data: *mut std::os::raw::c_void);
     /// Upcast a `WidgetExt` to a Widget
     /// # Safety
     /// Allows for potentially unsafe casts between incompatible widget types
@@ -433,10 +444,12 @@ pub unsafe trait WidgetBase: WidgetExt {
     /// takes the widget as a closure argument.
     /// macOS requires that `WidgetBase::draw` actually calls drawing functions
     fn draw<F: FnMut(&mut Self) + 'static>(&mut self, cb: F);
+    #[doc(hidden)]
     /// INTERNAL: Retrieve the draw data
     /// # Safety
     /// Can return multiple mutable references to the `draw_data`
     unsafe fn draw_data(&mut self) -> Option<Box<dyn FnMut()>>;
+    #[doc(hidden)]
     /// INTERNAL: Retrieve the handle data
     /// # Safety
     /// Can return multiple mutable references to the `handle_data`
@@ -586,6 +599,7 @@ pub unsafe trait WindowExt: GroupExt {
     fn free_position(&mut self);
     /// Get the raw system handle of the window
     fn raw_handle(&self) -> crate::window::RawHandle;
+    #[doc(hidden)]
     /// Set the window associated with a raw handle.
     /// `RawHandle` is a void pointer to: (Windows: `HWND`, X11: `Xid` (`u64`), macOS: `NSWindow`)
     /// # Safety
@@ -807,6 +821,7 @@ pub unsafe trait MenuExt: WidgetExt {
     /// # Safety
     /// Deletes `user_data` and any captured objects in the callback
     unsafe fn unsafe_clear(&mut self);
+    #[doc(hidden)]
     /// Clears a submenu by index, failure return `FltkErrorKind::FailedOperation`. Also recursively force-cleans capturing callbacks
     /// # Safety
     /// Deletes `user_data` and any captured objects in the callback
@@ -1248,6 +1263,7 @@ pub unsafe trait TableExt: GroupExt {
         &mut self,
         cb: F,
     );
+    #[doc(hidden)]
     /// INTERNAL: Retrieve the draw cell data
     /// # Safety
     /// Can return multiple mutable references to the `draw_cell_data`
@@ -1328,10 +1344,12 @@ pub unsafe trait ImageExt {
         Self: Sized;
     /// Checks if the image was deleted
     fn was_deleted(&self) -> bool;
+    #[doc(hidden)]
     /// INTERNAL: Manually increment the atomic refcount
     /// # Safety
     /// The underlying image pointer must be valid
     unsafe fn increment_arc(&mut self);
+    #[doc(hidden)]
     /// INTERNAL: Manually decrement the atomic refcount
     /// # Safety
     /// The underlying image pointer must be valid

--- a/fltk/src/prelude.rs
+++ b/fltk/src/prelude.rs
@@ -147,6 +147,14 @@ pub unsafe trait WidgetExt {
     fn center_of<W: WidgetExt>(self, w: &W) -> Self
     where
         Self: Sized;
+    /// Initialize center of another widget
+    fn center_x<W: WidgetExt>(self, w: &W) -> Self
+    where
+        Self: Sized;
+    /// Initialize center of another widget
+    fn center_y<W: WidgetExt>(self, w: &W) -> Self
+    where
+        Self: Sized;
     /// Initialize center of parent
     fn center_of_parent(self) -> Self
     where
@@ -1507,6 +1515,44 @@ macro_rules! widget_extends {
                 let wx = if w.as_window().is_some() { 0 } else { w.x() };
                 let wy = if w.as_window().is_some() { 0 } else { w.y() };
                 self.resize(sx as i32 + wx, sy as i32 + wy, sw as i32, sh as i32);
+                self.redraw();
+                self
+            }
+
+            /// Initialize center of another widget
+            pub fn center_x<W: $crate::prelude::WidgetExt>(mut self, w: &W) -> Self {
+                assert!(!w.was_deleted());
+                assert!(!self.was_deleted());
+                debug_assert!(
+                    w.width() != 0 && w.height() != 0,
+                    "center_of requires the size of the widget to be known!"
+                );
+                let sw = self.width() as f64;
+                let sh = self.height() as f64;
+                let ww = w.width() as f64;
+                let sx = (ww - sw) / 2.0;
+                let sy = self.y();
+                let wx = if w.as_window().is_some() { 0 } else { w.x() };
+                self.resize(sx as i32 + wx, sy, sw as i32, sh as i32);
+                self.redraw();
+                self
+            }
+
+            /// Initialize center of another widget
+            pub fn center_y<W: $crate::prelude::WidgetExt>(mut self, w: &W) -> Self {
+                assert!(!w.was_deleted());
+                assert!(!self.was_deleted());
+                debug_assert!(
+                    w.width() != 0 && w.height() != 0,
+                    "center_of requires the size of the widget to be known!"
+                );
+                let sw = self.width() as f64;
+                let sh = self.height() as f64;
+                let wh = w.height() as f64;
+                let sx = self.x();
+                let sy = (wh - sh) / 2.0;
+                let wy = if w.as_window().is_some() { 0 } else { w.y() };
+                self.resize(sx, sy as i32 + wy, sw as i32, sh as i32);
                 self.redraw();
                 self
             }


### PR DESCRIPTION
- Add WidgetExt::center_x() and center_y().
- Allow scraping examples for docs.rs.
- Add Fl_Flex::remove to C wrapper.
- Expose WidgetExt::raw_user_data() and set_raw_user_data().
- Pull fixes from FLTK.