### PR TITLE
Add mac_set_about

### DIFF
--- a/fltk-sys/src/menu.rs
+++ b/fltk-sys/src/menu.rs
@@ -1900,3 +1900,10 @@ extern "C" {
         idx: ::std::os::raw::c_int,
     ) -> *const Fl_Menu_Item;
 }
+extern "C" {
+    pub fn Fl_mac_set_about(
+        c: Fl_Callback,
+        user_data: *mut ::std::os::raw::c_void,
+        shortcut: ::std::os::raw::c_int,
+    );
+}


### PR DESCRIPTION
This adds the macOS specific function [`fl_mac_set_about`](https://www.fltk.org/doc-1.4/group__group__macosx.html). I hope I got the naming correct. Also I did not expose the `shortcut` parameter since the "About" menu usually isn't accessible with a shortcut and it'd require to always explicitly pass that parameter. I don't think that would be really convenient, but I'm open to change that.

Depends on MoAlyousef/cfltk#208