### PR TITLE
return Option<Widget> from TreeItem::widget

### DIFF
--- a/fltk/src/tree.rs
+++ b/fltk/src/tree.rs
@@ -1328,12 +1328,15 @@ impl TreeItem {
     }
 
     /// Gets the item's associated widget
-    pub fn widget(&self) -> Widget {
+    pub fn widget(&self) -> Option<Widget> {
         assert!(!self.was_deleted());
         unsafe {
-            Widget::from_widget_ptr(
-                Fl_Tree_Item_widget(self.inner) as *mut fltk_sys::widget::Fl_Widget
-            )
+            let ptr = Fl_Tree_Item_widget(self.inner) as *mut fltk_sys::widget::Fl_Widget;
+            if ptr.is_null() {
+                None
+            } else {
+                Some(Widget::from_widget_ptr(ptr))
+            }
         }
     }
 


### PR DESCRIPTION
`TreeItem` may not always contain a valid widget.
