### PR TITLE
1.2.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,15 @@
 # Changelog
 
 
-## [1.2.18] - Unreleased
-- [Security break] TreeItem::widget and Wizard::current_widget return an optional.
+## [1.2.18] - 2021-11-27
 - Add menu::mac_set_about(). Thanks @hannesbraun.
+- Add TreeItem::try_widget() and Wizard::try_current_widget().
 - Add app::version_str().
 - Add dialog::message_title() and message_title_default().
 - Shift experimental Flow widget to its own [crate](https://github.com/MoAlyousef/fltk-flow).
 - Add TreeItem::draw_item_content.
+- Add macros::widget::impl_widget_ext_via!() macro.
+- Deprecate TreeItem::widget(), wizard::current_widget() and Group::current().
 
 ## [1.2.17] - 2021-11-21
 - Add draw::draw_check().

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 ## [1.2.19] - Unreleased
 - Fix docs for dialog::message_title_default(). Thanks @hannesbraun.
 - Add TreeItem::set_label_fgcolor() and label_fgcolor(), deprecate the older names. Thanks @AshfordN.
+- Add TreeItem::as_ptr().
+- Add Tree::item_pathname().
 
 ## [1.2.18] - 2021-11-27
 - Add menu::mac_set_about(). Thanks @hannesbraun.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add TreeItem::set_label_fgcolor() and label_fgcolor(), deprecate the older names. Thanks @AshfordN.
 - Add TreeItem::as_ptr().
 - Add Tree::item_pathname().
+- Add enums::Key::F1 to F12, Key::is_fn_key() and Key::fn_key(i32).
 
 ## [1.2.18] - 2021-11-27
 - Add menu::mac_set_about(). Thanks @hannesbraun.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Add dialog::message_title() and message_title_default().
 - Shift experimental Flow widget to its own [crate](https://github.com/MoAlyousef/fltk-flow).
 - Add TreeItem::draw_item_content.
-- Add macros::widget::impl_widget_ext_via!() macro.
+- Expose several macros that assist in implementing some traits (WidgetExt, WidgetBase, GroupExt), useful for creating custom widgets.
 - Deprecate TreeItem::widget(), wizard::current_widget() and Group::current().
 
 ## [1.2.17] - 2021-11-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 
+## [1.2.19] - Unreleased
+- Fix docs for dialog::message_title_default(). Thanks @hannesbraun.
+- Add TreeItem::set_label_fgcolor() and label_fgcolor(), deprecate the older names. Thanks @AshfordN.
+
 ## [1.2.18] - 2021-11-27
 - Add menu::mac_set_about(). Thanks @hannesbraun.
 - Add TreeItem::try_widget() and Wizard::try_current_widget().

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-## [1.2.19] - Unreleased
+## [1.2.19] - 2021-12-03
 - Fix docs for dialog::message_title_default(). Thanks @hannesbraun.
 - Add TreeItem::set_label_fgcolor() and label_fgcolor(), deprecate the older names. Thanks @AshfordN.
 - Add TreeItem::as_ptr().

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,3 +1,5 @@
 # Roadmap for version 2 (ETA mid 2022). 
 
 - Rename WidgetExt::into_widget() to as_widget() and GroupExt::into_group() to as_group() to conform to Rust's self convention.
+- Rename TreeItem::try_widget() to widget() and remove old widget() method.
+- Rename Wizard::try_current_widget() to current_widget() and remove old current_widget() method.

--- a/fltk-sys/Cargo.toml
+++ b/fltk-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk-sys"
-version = "1.2.18"
+version = "1.2.19"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 build = "build/main.rs"
 edition = "2018"

--- a/fltk-sys/src/tree.rs
+++ b/fltk-sys/src/tree.rs
@@ -785,6 +785,14 @@ extern "C" {
     pub fn Fl_Tree_callback_reason(self_: *const Fl_Tree) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    pub fn Fl_Tree_item_pathname(
+        self_: *const Fl_Tree,
+        pathname: *mut ::std::os::raw::c_char,
+        pathnamelen: ::std::os::raw::c_int,
+        item: *const Fl_Tree_Item,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
     pub fn Fl_Tree_Item_new(
         tree: *mut Fl_Tree,
         txt: *const ::std::os::raw::c_char,

--- a/fltk/Cargo.toml
+++ b/fltk/Cargo.toml
@@ -66,6 +66,3 @@ harness = false
 name = "timeouts"
 path = "tests/timeouts.rs"
 harness = false
-
-[dev-dependencies]
-lazy_static = "*"

--- a/fltk/Cargo.toml
+++ b/fltk/Cargo.toml
@@ -66,3 +66,6 @@ harness = false
 name = "timeouts"
 path = "tests/timeouts.rs"
 harness = false
+
+[dev-dependencies]
+lazy_static = "*"

--- a/fltk/Cargo.toml
+++ b/fltk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk"
-version = "1.2.18"
+version = "1.2.19"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 edition = "2018"
 description = "Rust bindings for the FLTK GUI library"
@@ -17,7 +17,7 @@ name = "fltk"
 path = "src/lib.rs"
 
 [dependencies]
-fltk-sys = { path = "../fltk-sys", version = "=1.2.18" }
+fltk-sys = { path = "../fltk-sys", version = "=1.2.19" }
 bitflags = "^1.3"
 paste = "1"
 raw-window-handle = { version = "^0.3", optional = true }

--- a/fltk/src/browser.rs
+++ b/fltk/src/browser.rs
@@ -2,6 +2,7 @@ use crate::enums::{Align, CallbackTrigger, Color, Damage, Event, Font, FrameType
 use crate::image::Image;
 use crate::prelude::*;
 use crate::utils::FlString;
+use crate::window::Window;
 use fltk_sys::browser::*;
 use std::{
     ffi::{CStr, CString},

--- a/fltk/src/button.rs
+++ b/fltk/src/button.rs
@@ -4,6 +4,7 @@ use crate::enums::{
 use crate::image::Image;
 use crate::prelude::*;
 use crate::utils::FlString;
+use crate::window::Window;
 use fltk_sys::button::*;
 use std::{
     ffi::{CStr, CString},

--- a/fltk/src/dialog.rs
+++ b/fltk/src/dialog.rs
@@ -1153,7 +1153,7 @@ pub fn message_title(title: &str) {
     unsafe { Fl_message_title(title.as_ptr() as _) }
 }
 
-/// Set the next dialog's title
+/// Set the default title for a dialog
 pub fn message_title_default(title: &str) {
     let title = CString::safe_new(title);
     unsafe { Fl_message_title_default(title.as_ptr() as _) }

--- a/fltk/src/enums.rs
+++ b/fltk/src/enums.rs
@@ -869,7 +869,7 @@ impl Key {
 
     /// Return the corresponding function key
     pub const fn fn_key(val: i32) -> Key {
-        Key::from_i32(Key::F1.bits() - 1 + val;)
+        Key::from_i32(Key::F1.bits() - 1 + val)
     }
 }
 

--- a/fltk/src/enums.rs
+++ b/fltk/src/enums.rs
@@ -788,7 +788,31 @@ bitflags::bitflags! {
         const KPEnter = 0xff8d;
         /// Keypad Last
         const KPLast = 0xffbd;
-        /// FLast
+        /// F1
+        const F1 = 0xffbd + 1;
+        /// F2
+        const F2 = 0xffbd + 2;
+        /// F3
+        const F3 = 0xffbd + 3;
+        /// F4
+        const F4 = 0xffbd + 4;
+        /// F5
+        const F5 = 0xffbd + 5;
+        /// F6
+        const F6 = 0xffbd + 6;
+        /// F7
+        const F7 = 0xffbd + 7;
+        /// F8
+        const F8 = 0xffbd + 8;
+        /// F9
+        const F9 = 0xffbd + 9;
+        /// F10
+        const F10 = 0xffbd + 10;
+        /// F11
+        const F11 = 0xffbd + 11;
+        /// F12
+        const F12 = 0xffbd + 12;
+        /// Function key last
         const FLast = 0xffe0;
         /// Shift Left
         const ShiftL = 0xffe1;
@@ -835,6 +859,21 @@ impl Key {
             None
         } else {
             Some(bits as u8 as char)
+        }
+    }
+
+    /// Returns whether a key is a function key
+    pub const fn is_fn_key(key: Key) -> bool {
+        key.bits() >= Key::F1.bits() && key.bits() < Key::FLast.bits()
+    }
+
+    /// Return the corresponding function key
+    pub const fn fn_key(val: i32) -> Option<Key> {
+        let key = Key::F1.bits() + (val - 1);
+        if key < Key::FLast.bits() {
+            Some(Key::from_i32(key))
+        } else {
+            None
         }
     }
 }

--- a/fltk/src/enums.rs
+++ b/fltk/src/enums.rs
@@ -868,13 +868,8 @@ impl Key {
     }
 
     /// Return the corresponding function key
-    pub const fn fn_key(val: i32) -> Option<Key> {
-        let key = Key::F1.bits() + (val - 1);
-        if key < Key::FLast.bits() {
-            Some(Key::from_i32(key))
-        } else {
-            None
-        }
+    pub const fn fn_key(val: i32) -> Key {
+        Key::from_i32(Key::F1.bits() - 1 + val;)
     }
 }
 

--- a/fltk/src/frame.rs
+++ b/fltk/src/frame.rs
@@ -2,6 +2,7 @@ use crate::enums::{Align, CallbackTrigger, Color, Damage, Event, Font, FrameType
 use crate::image::Image;
 use crate::prelude::*;
 use crate::utils::FlString;
+use crate::window::Window;
 use fltk_sys::frame::*;
 use std::{
     ffi::{CStr, CString},

--- a/fltk/src/group.rs
+++ b/fltk/src/group.rs
@@ -2,6 +2,7 @@ use crate::enums::{Align, CallbackTrigger, Color, Damage, Event, Font, FrameType
 use crate::image::Image;
 use crate::prelude::*;
 use crate::utils::FlString;
+use crate::window::Window;
 use crate::widget::Widget;
 use fltk_sys::group::*;
 use std::{

--- a/fltk/src/group.rs
+++ b/fltk/src/group.rs
@@ -23,6 +23,7 @@ crate::macros::widget::impl_widget_base!(Group, Fl_Group);
 crate::macros::group::impl_group_ext!(Group, Fl_Group);
 
 impl Group {
+    #[deprecated(since="1.2.18", note="please use `try_current` instead")]
     /// Get the current group
     pub fn current() -> Group {
         unsafe {
@@ -335,8 +336,19 @@ impl Wizard {
         unsafe { Fl_Wizard_prev(self.inner) }
     }
 
+    #[deprecated(since="1.2.18", note="please use `try_current_widget` instead")]
     /// Gets the underlying widget of the current view
-    pub fn current_widget(&mut self) -> Option<impl WidgetExt> {
+    pub fn current_widget(&mut self) -> Widget {
+        unsafe {
+            assert!(!self.was_deleted());
+            let ptr = Fl_Wizard_value(self.inner) as *mut fltk_sys::widget::Fl_Widget;
+            assert!(!ptr.is_null());
+            Widget::from_widget_ptr(ptr)
+        }
+    }
+
+    /// Gets the underlying widget of the current view
+    pub fn try_current_widget(&mut self) -> Option<impl WidgetExt> {
         unsafe {
             assert!(!self.was_deleted());
             let ptr = Fl_Wizard_value(self.inner) as *mut fltk_sys::widget::Fl_Widget;

--- a/fltk/src/input.rs
+++ b/fltk/src/input.rs
@@ -2,6 +2,7 @@ use crate::enums::{Align, CallbackTrigger, Color, Damage, Event, Font, FrameType
 use crate::image::Image;
 use crate::prelude::*;
 use crate::utils::FlString;
+use crate::window::Window;
 use fltk_sys::input::*;
 use std::{
     ffi::{CStr, CString},

--- a/fltk/src/macros/widget.rs
+++ b/fltk/src/macros/widget.rs
@@ -1080,6 +1080,7 @@ pub use impl_widget_base;
 pub use impl_widget_ext;
 pub use impl_widget_type;
 
+
 #[macro_export]
 /// Implements WidgetExt via a member
 macro_rules! impl_widget_ext_via {
@@ -1216,7 +1217,7 @@ macro_rules! impl_widget_ext_via {
                 self.$member.measure_label()
             }
 
-            unsafe fn as_widget_ptr(&self) -> *mut fltk_sys::widget::Fl_Widget {
+            unsafe fn as_widget_ptr(&self) -> crate::app::WidgetPtr {
                 self.$member.as_widget_ptr()
             }
 
@@ -1533,7 +1534,7 @@ macro_rules! impl_widget_base_via {
                 <$base>::delete(wid.$member)
             }
 
-            unsafe fn from_widget_ptr(ptr: *mut fltk_sys::widget::Fl_Widget) -> Self {
+            unsafe fn from_widget_ptr(ptr: crate::app::WidgetPtr) -> Self {
                 let $member = <$base>::from_widget_ptr(ptr);
                 Self {
                     $member,

--- a/fltk/src/macros/widget.rs
+++ b/fltk/src/macros/widget.rs
@@ -51,7 +51,7 @@ macro_rules! impl_widget_ext {
                     self
                 }
 
-                fn with_align(mut self, align: crate::enums::Align) -> Self {
+                fn with_align(mut self, align: Align) -> Self {
                     self.set_align(align);
                     self
                 }
@@ -505,7 +505,7 @@ macro_rules! impl_widget_ext {
                         if wind_ptr.is_null() {
                             None
                         } else {
-                            Some(Box::new(crate::window::Window::from_widget_ptr(
+                            Some(Box::new(Window::from_widget_ptr(
                                 wind_ptr as *mut fltk_sys::widget::Fl_Widget,
                             )))
                         }
@@ -519,7 +519,7 @@ macro_rules! impl_widget_ext {
                         if wind_ptr.is_null() {
                             None
                         } else {
-                            Some(Box::new(crate::window::Window::from_widget_ptr(
+                            Some(Box::new(Window::from_widget_ptr(
                                 wind_ptr as *mut fltk_sys::widget::Fl_Widget,
                             )))
                         }
@@ -627,7 +627,7 @@ macro_rules! impl_widget_ext {
                         if ptr.is_null() {
                             return None;
                         }
-                        Some(Box::new(crate::window::Window::from_widget_ptr(
+                        Some(Box::new(Window::from_widget_ptr(
                             ptr as *mut fltk_sys::widget::Fl_Widget,
                         )))
                     }
@@ -1101,7 +1101,7 @@ macro_rules! impl_widget_ext_via {
                 self
             }
 
-            fn with_align(mut self, align: crate::enums::Align) -> Self {
+            fn with_align(mut self, align: Align) -> Self {
                 self.$member = self.$member.with_align(align);
                 self
             }

--- a/fltk/src/menu.rs
+++ b/fltk/src/menu.rs
@@ -4,6 +4,7 @@ use crate::enums::{
 use crate::image::Image;
 use crate::prelude::*;
 use crate::utils::FlString;
+use crate::window::Window;
 use fltk_sys::menu::*;
 use std::{
     ffi::{CStr, CString},

--- a/fltk/src/misc.rs
+++ b/fltk/src/misc.rs
@@ -2,8 +2,8 @@ use crate::enums::{Align, CallbackTrigger, Color, Damage, Event, Font, FrameType
 use crate::image::Image;
 use crate::prelude::*;
 use crate::utils::FlString;
-use crate::widget::Widget;
 use crate::window::Window;
+use crate::widget::Widget;
 use fltk_sys::misc::*;
 use std::{
     ffi::{CStr, CString},

--- a/fltk/src/output.rs
+++ b/fltk/src/output.rs
@@ -2,6 +2,7 @@ use crate::enums::{Align, CallbackTrigger, Color, Damage, Event, Font, FrameType
 use crate::image::Image;
 use crate::prelude::*;
 use crate::utils::FlString;
+use crate::window::Window;
 use fltk_sys::input::*;
 use std::{
     ffi::{CStr, CString},

--- a/fltk/src/prelude.rs
+++ b/fltk/src/prelude.rs
@@ -29,6 +29,7 @@ unsafe impl Sync for FltkError {}
 
 /// Error kinds enum for `FltkError`
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[non_exhaustive]
 pub enum FltkErrorKind {
     /// Failed to run the application
     FailedToRun,

--- a/fltk/src/table.rs
+++ b/fltk/src/table.rs
@@ -2,6 +2,7 @@ use crate::enums::{Align, CallbackTrigger, Color, Damage, Event, Font, FrameType
 use crate::image::Image;
 use crate::prelude::*;
 use crate::utils::FlString;
+use crate::window::Window;
 use crate::widget::Widget;
 use fltk_sys::table::*;
 use std::{

--- a/fltk/src/text.rs
+++ b/fltk/src/text.rs
@@ -2,6 +2,7 @@ use crate::enums::{Align, CallbackTrigger, Color, Damage, Event, Font, FrameType
 use crate::image::Image;
 use crate::prelude::*;
 use crate::utils::FlString;
+use crate::window::Window;
 use fltk_sys::text::*;
 use std::{
     ffi::{CStr, CString},

--- a/fltk/src/tree.rs
+++ b/fltk/src/tree.rs
@@ -1381,13 +1381,13 @@ impl TreeItem {
     }
 
     /// Sets the label's foreground color
-    pub fn set_label_fg_color(&mut self, val: Color) {
+    pub fn set_label_fgcolor(&mut self, val: Color) {
         assert!(!self.was_deleted());
         unsafe { Fl_Tree_Item_set_labelfgcolor(self.inner, val.bits() as u32) }
     }
 
     /// Gets the label's foreground color
-    pub fn label_fg_color(&self) -> Color {
+    pub fn label_fgcolor(&self) -> Color {
         assert!(!self.was_deleted());
         unsafe { mem::transmute(Fl_Tree_Item_labelfgcolor(self.inner)) }
     }

--- a/fltk/src/tree.rs
+++ b/fltk/src/tree.rs
@@ -1149,6 +1149,23 @@ impl Tree {
         assert!(!self.was_deleted());
         unsafe { mem::transmute(Fl_Tree_callback_reason(self.inner)) }
     }
+
+    /// Get an item's pathname
+    pub fn item_pathname(&self, item: &TreeItem) -> Result<String, FltkError> {
+        assert!(!self.was_deleted());
+        let mut temp = vec![0u8; 256];
+        unsafe {
+            let ret = Fl_Tree_item_pathname(self.inner, temp.as_mut_ptr() as _, 256, item.inner);
+            if ret == 0 {
+                if let Some(pos) =  temp.iter().position(|x| *x == 0) {
+                    temp = temp.split_at(pos).0.to_vec();
+                }
+                Ok(String::from_utf8_lossy(&temp).to_string())
+            } else {
+                Err(FltkError::Internal(FltkErrorKind::FailedOperation))
+            }
+        }
+    }
 }
 
 impl IntoIterator for Tree {
@@ -1835,6 +1852,11 @@ impl TreeItem {
         } else {
             unsafe { Fl_Tree_Item_set_usericon(self.inner, std::ptr::null_mut::<raw::c_void>()) }
         }
+    }
+
+    /// Return the internal pointer of the tree item
+    pub fn as_ptr(&self) -> *mut Fl_Tree_Item {
+        self.inner
     }
 }
 

--- a/fltk/src/tree.rs
+++ b/fltk/src/tree.rs
@@ -1423,8 +1423,19 @@ impl TreeItem {
         unsafe { Fl_Tree_Item_set_widget(self.inner, val.as_widget_ptr() as *mut Fl_Widget) }
     }
 
+    #[deprecated(since="1.2.18", note="please use `try_widget` instead")]
     /// Gets the item's associated widget
-    pub fn widget(&self) -> Option<impl WidgetExt> {
+    pub fn widget(&self) -> Widget {
+        assert!(!self.was_deleted());
+        unsafe {
+            let ptr = Fl_Tree_Item_widget(self.inner) as *mut fltk_sys::widget::Fl_Widget;
+            assert!(!ptr.is_null());
+            Widget::from_widget_ptr(ptr)
+        }
+    }
+
+    /// Gets the item's associated widget
+    pub fn try_widget(&self) -> Option<impl WidgetExt> {
         assert!(!self.was_deleted());
         unsafe {
             let ptr = Fl_Tree_Item_widget(self.inner) as *mut fltk_sys::widget::Fl_Widget;

--- a/fltk/src/tree.rs
+++ b/fltk/src/tree.rs
@@ -1392,6 +1392,20 @@ impl TreeItem {
         unsafe { mem::transmute(Fl_Tree_Item_labelfgcolor(self.inner)) }
     }
 
+    #[deprecated(since="1.2.19", note="please use `set_label_fgcolor` instead")]
+    /// Sets the label's foreground color
+    pub fn set_label_fg_color(&mut self, val: Color) {
+        assert!(!self.was_deleted());
+        unsafe { Fl_Tree_Item_set_labelfgcolor(self.inner, val.bits() as u32) }
+    }
+
+    #[deprecated(since="1.2.19", note="please use `label_fgcolor` instead")]
+    /// Gets the label's foreground color
+    pub fn label_fg_color(&self) -> Color {
+        assert!(!self.was_deleted());
+        unsafe { mem::transmute(Fl_Tree_Item_labelfgcolor(self.inner)) }
+    }
+
     /// Sets the label's color
     pub fn set_label_color(&mut self, val: Color) {
         assert!(!self.was_deleted());

--- a/fltk/src/tree.rs
+++ b/fltk/src/tree.rs
@@ -2,6 +2,7 @@ use crate::enums::{Align, CallbackTrigger, Color, Damage, Event, Font, FrameType
 use crate::image::Image;
 use crate::prelude::*;
 use crate::utils::FlString;
+use crate::window::Window;
 use crate::widget::Widget;
 use fltk_sys::tree::*;
 use std::{

--- a/fltk/src/valuator.rs
+++ b/fltk/src/valuator.rs
@@ -2,6 +2,7 @@ use crate::enums::{Align, CallbackTrigger, Color, Damage, Event, Font, FrameType
 use crate::image::Image;
 use crate::prelude::*;
 use crate::utils::FlString;
+use crate::window::Window;
 use fltk_sys::valuator::*;
 use std::{
     ffi::{CStr, CString},

--- a/fltk/src/widget.rs
+++ b/fltk/src/widget.rs
@@ -2,6 +2,7 @@ use crate::enums::{Align, CallbackTrigger, Color, Damage, Event, Font, FrameType
 use crate::image::Image;
 use crate::prelude::*;
 use crate::utils::FlString;
+use crate::window::Window;
 use fltk_sys::widget::*;
 use std::ffi::{CStr, CString};
 use std::mem;


### PR DESCRIPTION
- Fix docs for dialog::message_title_default(). Thanks @hannesbraun.
- Add TreeItem::set_label_fgcolor() and label_fgcolor(), deprecate the older names. Thanks @AshfordN.
- Add TreeItem::as_ptr().
- Add Tree::item_pathname().
- Add enums::Key::F1 to F12, Key::is_fn_key() and Key::fn_key(i32).