### PR TITLE
cleanup macros and surrounding API

### DIFF
--- a/fltk/src/browser.rs
+++ b/fltk/src/browser.rs
@@ -1,8 +1,6 @@
-use crate::enums::{Align, CallbackTrigger, Color, Damage, Event, Font, FrameType, LabelType};
-use crate::image::Image;
+use crate::enums::{Color, Font};
 use crate::prelude::*;
 use crate::utils::FlString;
-use crate::window::Window;
 use fltk_sys::browser::*;
 use std::{
     ffi::{CStr, CString},

--- a/fltk/src/button.rs
+++ b/fltk/src/button.rs
@@ -1,16 +1,7 @@
-use crate::enums::{
-    Align, CallbackTrigger, Color, Damage, Event, Font, FrameType, LabelType, Shortcut,
-};
-use crate::image::Image;
 use crate::prelude::*;
 use crate::utils::FlString;
-use crate::window::Window;
 use fltk_sys::button::*;
-use std::{
-    ffi::{CStr, CString},
-    mem,
-    os::raw,
-};
+use std::ffi::{CStr, CString};
 
 /// Creates a normal button
 #[derive(Debug)]

--- a/fltk/src/frame.rs
+++ b/fltk/src/frame.rs
@@ -1,14 +1,7 @@
-use crate::enums::{Align, CallbackTrigger, Color, Damage, Event, Font, FrameType, LabelType};
-use crate::image::Image;
 use crate::prelude::*;
 use crate::utils::FlString;
-use crate::window::Window;
 use fltk_sys::frame::*;
-use std::{
-    ffi::{CStr, CString},
-    mem,
-    os::raw,
-};
+use std::ffi::{CStr, CString};
 
 /// Creates a new frame, an equivalent of `Fl_Box`
 #[derive(Debug)]

--- a/fltk/src/group.rs
+++ b/fltk/src/group.rs
@@ -1,14 +1,11 @@
-use crate::enums::{Align, CallbackTrigger, Color, Damage, Event, Font, FrameType, LabelType};
-use crate::image::Image;
+use crate::enums::Align;
 use crate::prelude::*;
 use crate::utils::FlString;
-use crate::window::Window;
 use crate::widget::Widget;
 use fltk_sys::group::*;
 use std::{
     ffi::{CStr, CString},
     mem,
-    os::raw,
 };
 
 /// Creates a group widget
@@ -24,7 +21,7 @@ crate::macros::widget::impl_widget_base!(Group, Fl_Group);
 crate::macros::group::impl_group_ext!(Group, Fl_Group);
 
 impl Group {
-    #[deprecated(since="1.2.18", note="please use `try_current` instead")]
+    #[deprecated(since = "1.2.18", note = "please use `try_current` instead")]
     /// Get the current group
     pub fn current() -> Group {
         unsafe {
@@ -337,7 +334,7 @@ impl Wizard {
         unsafe { Fl_Wizard_prev(self.inner) }
     }
 
-    #[deprecated(since="1.2.18", note="please use `try_current_widget` instead")]
+    #[deprecated(since = "1.2.18", note = "please use `try_current_widget` instead")]
     /// Gets the underlying widget of the current view
     pub fn current_widget(&mut self) -> Widget {
         unsafe {

--- a/fltk/src/image.rs
+++ b/fltk/src/image.rs
@@ -2,11 +2,7 @@ use crate::enums::ColorDepth;
 use crate::prelude::*;
 use crate::utils::FlString;
 use fltk_sys::image::*;
-use std::{
-    ffi::CString,
-    mem,
-    sync::atomic::{AtomicUsize, Ordering},
-};
+use std::{ffi::CString, mem, sync::atomic::AtomicUsize};
 
 /// Wrapper around `Fl_Image`, used to wrap other image types
 #[derive(Debug)]

--- a/fltk/src/input.rs
+++ b/fltk/src/input.rs
@@ -1,13 +1,10 @@
-use crate::enums::{Align, CallbackTrigger, Color, Damage, Event, Font, FrameType, LabelType};
-use crate::image::Image;
+use crate::enums::FrameType;
 use crate::prelude::*;
 use crate::utils::FlString;
-use crate::window::Window;
 use fltk_sys::input::*;
 use std::{
     ffi::{CStr, CString},
     mem,
-    os::raw,
 };
 
 /// Creates an input widget

--- a/fltk/src/macros/browser.rs
+++ b/fltk/src/macros/browser.rs
@@ -147,7 +147,7 @@ macro_rules! impl_browser_ext {
                             None
                         } else {
                             let img =
-                                Image::from_image_ptr(image_ptr as *mut fltk_sys::image::Fl_Image);
+                            $crate::image::Image::from_image_ptr(image_ptr as *mut fltk_sys::image::Fl_Image);
                             Some(Box::new(img))
                         }
                     }
@@ -220,7 +220,7 @@ macro_rules! impl_browser_ext {
                     unsafe {
                         let mut v = arr.to_vec();
                         v.push(0);
-                        let v = mem::ManuallyDrop::new(v);
+                        let v = std::mem::ManuallyDrop::new(v);
                         [<$flname _set_column_widths>](self.inner, v.as_ptr());
                     }
                 }
@@ -255,12 +255,12 @@ macro_rules! impl_browser_ext {
                     unsafe { [<$flname _set_hposition>](self.inner, pos as i32) }
                 }
 
-                fn has_scrollbar(&self) -> BrowserScrollbar {
+                fn has_scrollbar(&self) -> $crate::browser::BrowserScrollbar {
                     assert!(!self.was_deleted());
-                    unsafe { mem::transmute([<$flname _has_scrollbar>](self.inner)) }
+                    unsafe { std::mem::transmute([<$flname _has_scrollbar>](self.inner)) }
                 }
 
-                fn set_has_scrollbar(&mut self, mode: BrowserScrollbar) {
+                fn set_has_scrollbar(&mut self, mode: $crate::browser::BrowserScrollbar) {
                     assert!(!self.was_deleted());
                     unsafe {
                         [<$flname _set_has_scrollbar>](self.inner, mode as raw::c_uchar)
@@ -282,23 +282,23 @@ macro_rules! impl_browser_ext {
                     unsafe { [<$flname _sort>](self.inner) }
                 }
 
-                fn scrollbar(&self) -> crate::valuator::Scrollbar {
+                fn scrollbar(&self) -> $crate::valuator::Scrollbar {
                     assert!(!self.was_deleted());
                     unsafe {
                         let ptr = [<$flname _scrollbar>](self.inner);
                         assert!(!ptr.is_null());
-                        crate::valuator::Scrollbar::from_widget_ptr(
+                        $crate::valuator::Scrollbar::from_widget_ptr(
                             ptr as *mut fltk_sys::widget::Fl_Widget,
                         )
                     }
                 }
 
-                fn hscrollbar(&self) -> crate::valuator::Scrollbar {
+                fn hscrollbar(&self) -> $crate::valuator::Scrollbar {
                     assert!(!self.was_deleted());
                     unsafe {
                         let ptr = [<$flname _hscrollbar>](self.inner);
                         assert!(!ptr.is_null());
-                        crate::valuator::Scrollbar::from_widget_ptr(
+                        $crate::valuator::Scrollbar::from_widget_ptr(
                             ptr as *mut fltk_sys::widget::Fl_Widget,
                         )
                     }

--- a/fltk/src/macros/button.rs
+++ b/fltk/src/macros/button.rs
@@ -4,14 +4,14 @@ macro_rules! impl_button_ext {
     ($name: ident, $flname: ident) => {
         paste::paste! {
             unsafe impl ButtonExt for $name {
-                fn shortcut(&self) -> Shortcut {
+                fn shortcut(&self) -> $crate::enums::Shortcut {
                     unsafe {
                         assert!(!self.was_deleted());
-                        mem::transmute([<$flname _shortcut>](self.inner))
+                        std::mem::transmute([<$flname _shortcut>](self.inner))
                     }
                 }
 
-                fn set_shortcut(&mut self, shortcut: Shortcut) {
+                fn set_shortcut(&mut self, shortcut: $crate::enums::Shortcut) {
                     unsafe {
                         assert!(!self.was_deleted());
                         [<$flname _set_shortcut>](self.inner, shortcut.bits() as i32)
@@ -53,14 +53,14 @@ macro_rules! impl_button_ext {
                     }
                 }
 
-                fn set_down_frame(&mut self, f: FrameType) {
+                fn set_down_frame(&mut self, f: $crate::enums::FrameType) {
                     assert!(!self.was_deleted());
                     unsafe { [<$flname _set_down_box>](self.inner, f as i32) }
                 }
 
-                fn down_frame(&self) -> FrameType {
+                fn down_frame(&self) -> $crate::enums::FrameType {
                     assert!(!self.was_deleted());
-                    unsafe { mem::transmute([<$flname _down_box>](self.inner)) }
+                    unsafe { std::mem::transmute([<$flname _down_box>](self.inner)) }
                 }
             }
         }

--- a/fltk/src/macros/display.rs
+++ b/fltk/src/macros/display.rs
@@ -4,20 +4,20 @@ macro_rules! impl_display_ext {
     ($name: ident, $flname: ident) => {
         paste::paste! {
             unsafe impl DisplayExt for $name {
-                fn buffer(&self) -> Option<TextBuffer> {
+                fn buffer(&self) -> Option<$crate::text::TextBuffer> {
                     unsafe {
                         assert!(!self.was_deleted());
                         let buffer = [<$flname _get_buffer>](self.inner);
                         if buffer.is_null() {
                             None
                         } else {
-                            let buf = TextBuffer::from_ptr(buffer);
+                            let buf = $crate::text::TextBuffer::from_ptr(buffer);
                             Some(buf)
                         }
                     }
                 }
 
-                fn set_buffer<B: Into<Option<crate::text::TextBuffer>>>(&mut self, buffer: B) {
+                fn set_buffer<B: Into<Option<$crate::text::TextBuffer>>>(&mut self, buffer: B) {
                     unsafe {
                         assert!(!self.was_deleted());
                         if let Some(buffer) = buffer.into() {
@@ -32,38 +32,38 @@ macro_rules! impl_display_ext {
                     }
                 }
 
-                fn style_buffer(&self) -> Option<TextBuffer> {
+                fn style_buffer(&self) -> Option<$crate::text::TextBuffer> {
                     unsafe {
                         assert!(!self.was_deleted());
                         let buffer = [<$flname _get_style_buffer>](self.inner);
                         if buffer.is_null() {
                             None
                         } else {
-                            let buf = TextBuffer::from_ptr(buffer);
+                            let buf = $crate::text::TextBuffer::from_ptr(buffer);
                             Some(buf)
                         }
                     }
                 }
 
-                fn text_font(&self) -> Font {
+                fn text_font(&self) -> $crate::enums::Font {
                     assert!(!self.was_deleted());
                     assert!(self.buffer().is_some());
-                    unsafe { mem::transmute([<$flname _text_font>](self.inner)) }
+                    unsafe { std::mem::transmute([<$flname _text_font>](self.inner)) }
                 }
 
-                fn set_text_font(&mut self, font: Font) {
+                fn set_text_font(&mut self, font: $crate::enums::Font) {
                     assert!(!self.was_deleted());
                     assert!(self.buffer().is_some());
                     unsafe { [<$flname _set_text_font>](self.inner, font.bits() as i32) }
                 }
 
-                fn text_color(&self) -> Color {
+                fn text_color(&self) -> $crate::enums::Color {
                     assert!(!self.was_deleted());
                     assert!(self.buffer().is_some());
-                    unsafe { mem::transmute([<$flname _text_color>](self.inner)) }
+                    unsafe { std::mem::transmute([<$flname _text_color>](self.inner)) }
                 }
 
-                fn set_text_color(&mut self, color: Color) {
+                fn set_text_color(&mut self, color: $crate::enums::Color) {
                     assert!(!self.was_deleted());
                     assert!(self.buffer().is_some());
                     unsafe { [<$flname _set_text_color>](self.inner, color.bits() as u32) }
@@ -203,18 +203,18 @@ macro_rules! impl_display_ext {
                     }
                 }
 
-                fn set_highlight_data<B: Into<Option<TextBuffer>>>(
+                fn set_highlight_data<B: Into<Option<$crate::text::TextBuffer>>>(
                     &mut self,
                     style_buffer: B,
-                    entries: Vec<StyleTableEntry>,
+                    entries: Vec<$crate::text::StyleTableEntry>,
                 ) {
                     assert!(!self.was_deleted());
                     assert!(entries.len() < 61);
                     let entries = if entries.len() == 0 {
-                        vec![StyleTableEntry {
-                            color: Color::Black,
-                            font: Font::Helvetica,
-                            size: crate::app::font_size(),
+                        vec![$crate::text::StyleTableEntry {
+                            color: $crate::enums::Color::Black,
+                            font: $crate::enums::Font::Helvetica,
+                            size: $crate::app::font_size(),
                         }]
                     } else {
                         entries
@@ -256,11 +256,11 @@ macro_rules! impl_display_ext {
                     }
                 }
 
-                fn unset_highlight_data(&mut self, style_buffer: TextBuffer) {
+                fn unset_highlight_data(&mut self, style_buffer: $crate::text::TextBuffer) {
                     assert!(!self.was_deleted());
                     unsafe {
-                        let mut colors = [Color::Black.bits()];
-                        let mut fonts = [Font::Helvetica.bits()];
+                        let mut colors = [$crate::enums::Color::Black.bits()];
+                        let mut fonts = [$crate::enums::Font::Helvetica.bits()];
                         let mut sizes = [14];
                         [<$flname _set_highlight_data>](
                             self.inner,
@@ -273,14 +273,14 @@ macro_rules! impl_display_ext {
                     }
                 }
 
-                fn set_cursor_style(&mut self, style: crate::text::Cursor) {
+                fn set_cursor_style(&mut self, style: $crate::text::Cursor) {
                     unsafe {
                         assert!(!self.was_deleted());
                         [<$flname _set_cursor_style>](self.inner, style as i32)
                     }
                 }
 
-                fn set_cursor_color(&mut self, color: Color) {
+                fn set_cursor_color(&mut self, color: $crate::enums::Color) {
                     unsafe {
                         assert!(!self.was_deleted());
                         [<$flname _set_cursor_color>](self.inner, color.bits() as u32)
@@ -294,24 +294,24 @@ macro_rules! impl_display_ext {
                     }
                 }
 
-                fn set_scrollbar_align(&mut self, align: Align) {
+                fn set_scrollbar_align(&mut self, align: $crate::enums::Align) {
                     unsafe {
                         assert!(!self.was_deleted());
                         [<$flname _set_scrollbar_align>](self.inner, align.bits() as i32)
                     }
                 }
 
-                fn cursor_style(&self) -> crate::text::Cursor {
+                fn cursor_style(&self) -> $crate::text::Cursor {
                     unsafe {
                         assert!(!self.was_deleted());
-                        mem::transmute([<$flname _cursor_style>](self.inner))
+                        std::mem::transmute([<$flname _cursor_style>](self.inner))
                     }
                 }
 
-                fn cursor_color(&self) -> Color {
+                fn cursor_color(&self) -> $crate::enums::Color {
                     unsafe {
                         assert!(!self.was_deleted());
-                        mem::transmute([<$flname _cursor_color>](self.inner))
+                        std::mem::transmute([<$flname _cursor_color>](self.inner))
                     }
                 }
 
@@ -322,10 +322,10 @@ macro_rules! impl_display_ext {
                     }
                 }
 
-                fn scrollbar_align(&self) -> Align {
+                fn scrollbar_align(&self) -> $crate::enums::Align {
                     unsafe {
                         assert!(!self.was_deleted());
-                        mem::transmute([<$flname _scrollbar_align>](self.inner))
+                        std::mem::transmute([<$flname _scrollbar_align>](self.inner))
                     }
                 }
 
@@ -436,17 +436,17 @@ macro_rules! impl_display_ext {
                     }
                 }
 
-                fn set_linenumber_font(&mut self, font: Font) {
+                fn set_linenumber_font(&mut self, font: $crate::enums::Font) {
                     unsafe {
                         assert!(!self.was_deleted());
                         [<$flname _set_linenumber_font>](self.inner, font.bits() as i32)
                     }
                 }
 
-                fn linenumber_font(&self) -> Font {
+                fn linenumber_font(&self) -> $crate::enums::Font {
                     unsafe {
                         assert!(!self.was_deleted());
-                        mem::transmute([<$flname _linenumber_font>](self.inner))
+                        std::mem::transmute([<$flname _linenumber_font>](self.inner))
                     }
                 }
 
@@ -464,7 +464,7 @@ macro_rules! impl_display_ext {
                     }
                 }
 
-                fn set_linenumber_fgcolor(&mut self, color: Color) {
+                fn set_linenumber_fgcolor(&mut self, color: $crate::enums::Color) {
                     unsafe {
                         assert!(!self.was_deleted());
                         [<$flname _set_linenumber_fgcolor>](
@@ -474,14 +474,14 @@ macro_rules! impl_display_ext {
                     }
                 }
 
-                fn linenumber_fgcolor(&self) -> Color {
+                fn linenumber_fgcolor(&self) -> $crate::enums::Color {
                     unsafe {
                         assert!(!self.was_deleted());
-                        mem::transmute([<$flname _linenumber_fgcolor>](self.inner))
+                        std::mem::transmute([<$flname _linenumber_fgcolor>](self.inner))
                     }
                 }
 
-                fn set_linenumber_bgcolor(&mut self, color: Color) {
+                fn set_linenumber_bgcolor(&mut self, color: $crate::enums::Color) {
                     unsafe {
                         assert!(!self.was_deleted());
                         [<$flname _set_linenumber_bgcolor>](
@@ -491,24 +491,24 @@ macro_rules! impl_display_ext {
                     }
                 }
 
-                fn linenumber_bgcolor(&self) -> Color {
+                fn linenumber_bgcolor(&self) -> $crate::enums::Color {
                     unsafe {
                         assert!(!self.was_deleted());
-                        mem::transmute([<$flname _linenumber_bgcolor>](self.inner))
+                        std::mem::transmute([<$flname _linenumber_bgcolor>](self.inner))
                     }
                 }
 
-                fn set_linenumber_align(&mut self, align: Align) {
+                fn set_linenumber_align(&mut self, align: $crate::enums::Align) {
                     unsafe {
                         assert!(!self.was_deleted());
                         [<$flname _set_linenumber_align>](self.inner, align.bits() as i32)
                     }
                 }
 
-                fn linenumber_align(&self) -> Align {
+                fn linenumber_align(&self) -> $crate::enums::Align {
                     unsafe {
                         assert!(!self.was_deleted());
-                        mem::transmute([<$flname _linenumber_align>](self.inner))
+                        std::mem::transmute([<$flname _linenumber_align>](self.inner))
                     }
                 }
 
@@ -520,7 +520,7 @@ macro_rules! impl_display_ext {
                     }
                 }
 
-                fn wrap_mode(&mut self, wrap: crate::text::WrapMode, wrap_margin: i32) {
+                fn wrap_mode(&mut self, wrap: $crate::text::WrapMode, wrap_margin: i32) {
                     assert!(!self.was_deleted());
                     unsafe { [<$flname _wrap_mode>](self.inner, wrap as i32, wrap_margin) }
                 }

--- a/fltk/src/macros/group.rs
+++ b/fltk/src/macros/group.rs
@@ -3,11 +3,11 @@
 macro_rules! impl_group_ext {
     ($name: ident, $flname: ident) => {
         impl IntoIterator for $name {
-            type Item = Widget;
+            type Item = $crate::widget::Widget;
             type IntoIter = std::vec::IntoIter<Self::Item>;
 
             fn into_iter(self) -> Self::IntoIter {
-                let mut v: Vec<Widget> = vec![];
+                let mut v: Vec<$crate::widget::Widget> = vec![];
                 for i in 0..self.children() {
                     v.push(self.child(i).unwrap());
                 }
@@ -46,7 +46,7 @@ macro_rules! impl_group_ext {
                     }
                 }
 
-                fn child(&self, idx: i32) -> Option<Widget> {
+                fn child(&self, idx: i32) -> Option<$crate::widget::Widget> {
                     unsafe {
                         assert!(!self.was_deleted());
                         if idx >= self.children() || idx < 0 {
@@ -56,7 +56,7 @@ macro_rules! impl_group_ext {
                         if child_widget.is_null() {
                             None
                         } else {
-                            Some(Widget::from_widget_ptr(
+                            Some($crate::widget::Widget::from_widget_ptr(
                                 child_widget as *mut fltk_sys::widget::Fl_Widget,
                             ))
                         }
@@ -145,7 +145,7 @@ macro_rules! impl_group_ext {
                     assert!(!self.was_deleted());
                     assert!(!w.was_deleted());
                     unsafe {
-                        crate::app::open_display();
+                        $crate::app::open_display();
                         [<$flname _draw_child>](self.inner as _, w.as_widget_ptr() as _)
                     }
                 }
@@ -154,7 +154,7 @@ macro_rules! impl_group_ext {
                     assert!(!self.was_deleted());
                     assert!(!w.was_deleted());
                     unsafe {
-                        crate::app::open_display();
+                        $crate::app::open_display();
                         [<$flname _update_child>](self.inner as _, w.as_widget_ptr() as _)
                     }
                 }
@@ -163,7 +163,7 @@ macro_rules! impl_group_ext {
                     assert!(!self.was_deleted());
                     assert!(!w.was_deleted());
                     unsafe {
-                        crate::app::open_display();
+                        $crate::app::open_display();
                         [<$flname _draw_outside_label>](
                             self.inner as _,
                             w.as_widget_ptr() as _,
@@ -174,7 +174,7 @@ macro_rules! impl_group_ext {
                 fn draw_children(&mut self) {
                     assert!(!self.was_deleted());
                     unsafe {
-                        crate::app::open_display();
+                        $crate::app::open_display();
                         [<$flname _draw_children>](self.inner as _)
                     }
                 }
@@ -200,8 +200,8 @@ macro_rules! impl_group_ext {
                     vec
                 }
 
-                unsafe fn into_group(&self) -> crate::group::Group {
-                    crate::group::Group::from_widget_ptr(self.inner as _)
+                unsafe fn into_group(&self) -> $crate::group::Group {
+                    $crate::group::Group::from_widget_ptr(self.inner as _)
                 }
             }
         }
@@ -213,8 +213,8 @@ pub use impl_group_ext;
 #[macro_export]
 /// Implements GroupExt via a member
 macro_rules! impl_group_ext_via {
-    ($widget:ty, $member:tt) => {        
-        unsafe impl GroupExt for $widget {       
+    ($widget:ty, $member:tt) => {
+        unsafe impl GroupExt for $widget {
             fn begin(&self) {
                 self.$member.begin()
             }
@@ -235,7 +235,7 @@ macro_rules! impl_group_ext_via {
                 self.$member.children()
             }
 
-            fn child(&self, idx: i32) -> Option<Widget> {
+            fn child(&self, idx: i32) -> Option<$crate::widget::Widget> {
                 self.$member.child(idx)
             }
 
@@ -303,7 +303,7 @@ macro_rules! impl_group_ext_via {
                 self.$member.bounds()
             }
 
-            unsafe fn into_group(&self) -> crate::group::Group {
+            unsafe fn into_group(&self) -> $crate::group::Group {
                 self.$member.into_group()
             }
         }

--- a/fltk/src/macros/input.rs
+++ b/fltk/src/macros/input.rs
@@ -9,7 +9,7 @@ macro_rules! impl_input_ext {
                         assert!(!self.was_deleted());
                         let value_ptr = [<$flname _value>](self.inner);
                         assert!(!value_ptr.is_null());
-                        CStr::from_ptr(value_ptr as *mut raw::c_char)
+                        CStr::from_ptr(value_ptr as *mut std::os::raw::c_char)
                             .to_string_lossy()
                             .to_string()
                     }
@@ -148,28 +148,28 @@ macro_rules! impl_input_ext {
                     }
                 }
 
-                fn text_font(&self) -> Font {
+                fn text_font(&self) -> $crate::enums::Font {
                     unsafe {
                         assert!(!self.was_deleted());
-                        mem::transmute([<$flname _text_font>](self.inner))
+                        std::mem::transmute([<$flname _text_font>](self.inner))
                     }
                 }
 
-                fn set_text_font(&mut self, font: Font) {
+                fn set_text_font(&mut self, font: $crate::enums::Font) {
                     unsafe {
                         assert!(!self.was_deleted());
                         [<$flname _set_text_font>](self.inner, font.bits() as i32)
                     }
                 }
 
-                fn text_color(&self) -> Color {
+                fn text_color(&self) -> $crate::enums::Color {
                     unsafe {
                         assert!(!self.was_deleted());
-                        mem::transmute([<$flname _text_color>](self.inner))
+                        std::mem::transmute([<$flname _text_color>](self.inner))
                     }
                 }
 
-                fn set_text_color(&mut self, color: Color) {
+                fn set_text_color(&mut self, color: $crate::enums::Color) {
                     unsafe {
                         assert!(!self.was_deleted());
                         [<$flname _set_text_color>](self.inner, color.bits() as u32)

--- a/fltk/src/macros/menu.rs
+++ b/fltk/src/macros/menu.rs
@@ -20,23 +20,23 @@ macro_rules! impl_menu_ext {
                 fn add<F: FnMut(&mut Self) + 'static>(
                     &mut self,
                     name: &str,
-                    shortcut: Shortcut,
+                    shortcut: $crate::enums::Shortcut,
                     flag: MenuFlag,
                     cb: F,
                 ) -> i32 {
                     assert!(!self.was_deleted());
                     let temp = CString::safe_new(name);
                     unsafe {
-                        unsafe extern "C" fn shim(wid: *mut Fl_Widget, data: *mut raw::c_void) {
-                            let mut wid = crate::widget::Widget::from_widget_ptr(wid as *mut _);
-                            let a: *mut Box<dyn FnMut(&mut crate::widget::Widget)> =
-                                data as *mut Box<dyn FnMut(&mut crate::widget::Widget)>;
-                            let f: &mut (dyn FnMut(&mut crate::widget::Widget)) = &mut **a;
+                        unsafe extern "C" fn shim(wid: *mut Fl_Widget, data: *mut std::os::raw::c_void) {
+                            let mut wid = $crate::widget::Widget::from_widget_ptr(wid as *mut _);
+                            let a: *mut Box<dyn FnMut(&mut $crate::widget::Widget)> =
+                                data as *mut Box<dyn FnMut(&mut $crate::widget::Widget)>;
+                            let f: &mut (dyn FnMut(&mut $crate::widget::Widget)) = &mut **a;
                             let _ =
                                 std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| f(&mut wid)));
                         }
                         let a: *mut Box<dyn FnMut(&mut Self)> = Box::into_raw(Box::new(Box::new(cb)));
-                        let data: *mut raw::c_void = a as *mut raw::c_void;
+                        let data: *mut std::os::raw::c_void = a as *mut std::os::raw::c_void;
                         let callback: Fl_Callback = Some(shim);
                         [<$flname _add>](
                             self.inner,
@@ -53,23 +53,23 @@ macro_rules! impl_menu_ext {
                     &mut self,
                     idx: i32,
                     name: &str,
-                    shortcut: Shortcut,
+                    shortcut: $crate::enums::Shortcut,
                     flag: MenuFlag,
                     cb: F,
                 ) -> i32 {
                     assert!(!self.was_deleted());
                     let temp = CString::safe_new(name);
                     unsafe {
-                        unsafe extern "C" fn shim(wid: *mut Fl_Widget, data: *mut raw::c_void) {
-                            let mut wid = crate::widget::Widget::from_widget_ptr(wid as *mut _);
-                            let a: *mut Box<dyn FnMut(&mut crate::widget::Widget)> =
-                                data as *mut Box<dyn FnMut(&mut crate::widget::Widget)>;
-                            let f: &mut (dyn FnMut(&mut crate::widget::Widget)) = &mut **a;
+                        unsafe extern "C" fn shim(wid: *mut Fl_Widget, data: *mut std::os::raw::c_void) {
+                            let mut wid = $crate::widget::Widget::from_widget_ptr(wid as *mut _);
+                            let a: *mut Box<dyn FnMut(&mut $crate::widget::Widget)> =
+                                data as *mut Box<dyn FnMut(&mut $crate::widget::Widget)>;
+                            let f: &mut (dyn FnMut(&mut $crate::widget::Widget)) = &mut **a;
                             let _ =
                                 std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| f(&mut wid)));
                         }
                         let a: *mut Box<dyn FnMut(&mut Self)> = Box::into_raw(Box::new(Box::new(cb)));
-                        let data: *mut raw::c_void = a as *mut raw::c_void;
+                        let data: *mut std::os::raw::c_void = a as *mut std::os::raw::c_void;
                         let callback: Fl_Callback = Some(shim);
                         [<$flname _insert>](
                             self.inner,
@@ -86,9 +86,9 @@ macro_rules! impl_menu_ext {
                 fn add_emit<T: 'static + Clone + Send + Sync>(
                     &mut self,
                     label: &str,
-                    shortcut: Shortcut,
-                    flag: crate::menu::MenuFlag,
-                    sender: crate::app::Sender<T>,
+                    shortcut: $crate::enums::Shortcut,
+                    flag: $crate::menu::MenuFlag,
+                    sender: $crate::app::Sender<T>,
                     msg: T,
                 ) -> i32 {
                     self.add(label, shortcut, flag, move |_| sender.send(msg.clone()))
@@ -98,9 +98,9 @@ macro_rules! impl_menu_ext {
                     &mut self,
                     idx: i32,
                     label: &str,
-                    shortcut: Shortcut,
-                    flag: crate::menu::MenuFlag,
-                    sender: crate::app::Sender<T>,
+                    shortcut: $crate::enums::Shortcut,
+                    flag: $crate::menu::MenuFlag,
+                    sender: $crate::app::Sender<T>,
                     msg: T,
                 ) -> i32 {
                     self.insert(idx, label, shortcut, flag, move |_| {
@@ -147,14 +147,14 @@ macro_rules! impl_menu_ext {
                     unsafe { [<$flname _find_index>](self.inner, label.as_ptr()) as i32 }
                 }
 
-                fn text_font(&self) -> Font {
+                fn text_font(&self) -> $crate::enums::Font {
                     unsafe {
                         assert!(!self.was_deleted());
-                        mem::transmute([<$flname _text_font>](self.inner))
+                        std::mem::transmute([<$flname _text_font>](self.inner))
                     }
                 }
 
-                fn set_text_font(&mut self, c: Font) {
+                fn set_text_font(&mut self, c: $crate::enums::Font) {
                     unsafe {
                         assert!(!self.was_deleted());
                         [<$flname _set_text_font>](self.inner, c.bits() as i32)
@@ -175,14 +175,14 @@ macro_rules! impl_menu_ext {
                     }
                 }
 
-                fn text_color(&self) -> Color {
+                fn text_color(&self) -> $crate::enums::Color {
                     unsafe {
                         assert!(!self.was_deleted());
-                        mem::transmute([<$flname _text_color>](self.inner))
+                        std::mem::transmute([<$flname _text_color>](self.inner))
                     }
                 }
 
-                fn set_text_color(&mut self, c: Color) {
+                fn set_text_color(&mut self, c: $crate::enums::Color) {
                     unsafe {
                         assert!(!self.was_deleted());
                         [<$flname _set_text_color>](self.inner, c.bits() as u32)
@@ -195,7 +195,7 @@ macro_rules! impl_menu_ext {
                         let arg2 = CString::safe_new(text);
                         [<$flname _add_choice>](
                             self.inner,
-                            arg2.as_ptr() as *mut raw::c_char,
+                            arg2.as_ptr() as *mut std::os::raw::c_char,
                         )
                     }
                 }
@@ -208,7 +208,7 @@ macro_rules! impl_menu_ext {
                             None
                         } else {
                             Some(
-                                CStr::from_ptr(choice_ptr as *mut raw::c_char)
+                                CStr::from_ptr(choice_ptr as *mut std::os::raw::c_char)
                                     .to_string_lossy()
                                     .to_string(),
                             )
@@ -300,7 +300,7 @@ macro_rules! impl_menu_ext {
                             None
                         } else {
                             Some(
-                                CStr::from_ptr(text as *mut raw::c_char)
+                                CStr::from_ptr(text as *mut std::os::raw::c_char)
                                     .to_string_lossy()
                                     .to_string(),
                             )
@@ -308,7 +308,7 @@ macro_rules! impl_menu_ext {
                     }
                 }
 
-                fn at(&self, idx: i32) -> Option<crate::menu::MenuItem> {
+                fn at(&self, idx: i32) -> Option<$crate::menu::MenuItem> {
                     assert!(!self.was_deleted());
                     if idx >= self.size() || idx < 0 {
                         return None;
@@ -327,12 +327,12 @@ macro_rules! impl_menu_ext {
                     }
                 }
 
-                fn mode(&self, idx: i32) -> crate::menu::MenuFlag {
+                fn mode(&self, idx: i32) -> $crate::menu::MenuFlag {
                     assert!(!self.was_deleted());
-                    unsafe { mem::transmute([<$flname _mode>](self.inner, idx as i32)) }
+                    unsafe { std::mem::transmute([<$flname _mode>](self.inner, idx as i32)) }
                 }
 
-                fn set_mode(&mut self, idx: i32, flag: crate::menu::MenuFlag) {
+                fn set_mode(&mut self, idx: i32, flag: $crate::menu::MenuFlag) {
                     assert!(!self.was_deleted());
                     unsafe { [<$flname _set_mode>](self.inner, idx as i32, flag as i32) }
                 }
@@ -341,14 +341,14 @@ macro_rules! impl_menu_ext {
                     //
                 }
 
-                fn set_down_frame(&mut self, f: FrameType) {
+                fn set_down_frame(&mut self, f: $crate::enums::FrameType) {
                     assert!(!self.was_deleted());
                     unsafe { [<$flname _set_down_box>](self.inner, f as i32) }
                 }
 
-                fn down_frame(&self) -> FrameType {
+                fn down_frame(&self) -> $crate::enums::FrameType {
                     assert!(!self.was_deleted());
-                    unsafe { mem::transmute([<$flname _down_box>](self.inner)) }
+                    unsafe { std::mem::transmute([<$flname _down_box>](self.inner)) }
                 }
 
                 fn global(&mut self) {
@@ -356,7 +356,7 @@ macro_rules! impl_menu_ext {
                     unsafe { [<$flname _global>](self.inner) }
                 }
 
-                fn menu(&self) -> Option<crate::menu::MenuItem> {
+                fn menu(&self) -> Option<$crate::menu::MenuItem> {
                     assert!(!self.was_deleted());
                     unsafe {
                         let ptr = [<$flname _menu>](self.inner);
@@ -371,7 +371,7 @@ macro_rules! impl_menu_ext {
                     }
                 }
 
-                unsafe fn set_menu(&mut self, item: crate::menu::MenuItem) {
+                unsafe fn set_menu(&mut self, item: $crate::menu::MenuItem) {
                     assert!(!self.was_deleted());
                     [<$flname _set_menu>](self.inner, item.inner)
                 }

--- a/fltk/src/macros/table.rs
+++ b/fltk/src/macros/table.rs
@@ -11,17 +11,17 @@ macro_rules! impl_table_ext {
                     }
                 }
 
-                fn set_table_frame(&mut self, frame: FrameType) {
+                fn set_table_frame(&mut self, frame: $crate::enums::FrameType) {
                     unsafe {
                         assert!(!self.was_deleted());
                         [<$flname _set_table_box>](self.inner, frame as i32)
                     }
                 }
 
-                fn table_frame(&self) -> FrameType {
+                fn table_frame(&self) -> $crate::enums::FrameType {
                     unsafe {
                         assert!(!self.was_deleted());
-                        mem::transmute([<$flname _table_box>](self.inner))
+                        std::mem::transmute([<$flname _table_box>](self.inner))
                     }
                 }
 
@@ -190,31 +190,31 @@ macro_rules! impl_table_ext {
                     }
                 }
 
-                fn set_row_header_color(&mut self, val: Color) {
+                fn set_row_header_color(&mut self, val: $crate::enums::Color) {
                     unsafe {
                         assert!(!self.was_deleted());
                         [<$flname _set_row_header_color>](self.inner, val.bits() as u32)
                     }
                 }
 
-                fn row_header_color(&self) -> Color {
+                fn row_header_color(&self) -> $crate::enums::Color {
                     unsafe {
                         assert!(!self.was_deleted());
-                        mem::transmute([<$flname _row_header_color>](self.inner))
+                        std::mem::transmute([<$flname _row_header_color>](self.inner))
                     }
                 }
 
-                fn set_col_header_color(&mut self, val: Color) {
+                fn set_col_header_color(&mut self, val: $crate::enums::Color) {
                     unsafe {
                         assert!(!self.was_deleted());
                         [<$flname _set_col_header_color>](self.inner, val.bits() as u32)
                     }
                 }
 
-                fn col_header_color(&self) -> Color {
+                fn col_header_color(&self) -> $crate::enums::Color {
                     unsafe {
                         assert!(!self.was_deleted());
-                        mem::transmute([<$flname _col_header_color>](self.inner))
+                        std::mem::transmute([<$flname _col_header_color>](self.inner))
                     }
                 }
 
@@ -401,7 +401,7 @@ macro_rules! impl_table_ext {
                 }
 
                 fn draw_cell<
-                    F: FnMut(&mut Self, crate::table::TableContext, i32, i32, i32, i32, i32, i32)
+                    F: FnMut(&mut Self, $crate::table::TableContext, i32, i32, i32, i32, i32, i32)
                         + 'static,
                 >(
                     &mut self,
@@ -411,34 +411,34 @@ macro_rules! impl_table_ext {
                     pub type CustomDrawCellCallback = Option<
                         unsafe extern "C" fn(
                             wid: *mut Fl_Widget,
-                            ctx: raw::c_int,
-                            arg2: raw::c_int,
-                            arg3: raw::c_int,
-                            arg4: raw::c_int,
-                            arg5: raw::c_int,
-                            arg6: raw::c_int,
-                            arg7: raw::c_int,
-                            data: *mut raw::c_void,
+                            ctx: std::os::raw::c_int,
+                            arg2: std::os::raw::c_int,
+                            arg3: std::os::raw::c_int,
+                            arg4: std::os::raw::c_int,
+                            arg5: std::os::raw::c_int,
+                            arg6: std::os::raw::c_int,
+                            arg7: std::os::raw::c_int,
+                            data: *mut std::os::raw::c_void,
                         ),
                     >;
                     unsafe {
                         unsafe extern "C" fn shim(
                             wid: *mut Fl_Widget,
-                            ctx: raw::c_int,
-                            arg2: raw::c_int,
-                            arg3: raw::c_int,
-                            arg4: raw::c_int,
-                            arg5: raw::c_int,
-                            arg6: raw::c_int,
-                            arg7: raw::c_int,
-                            data: *mut raw::c_void,
+                            ctx: std::os::raw::c_int,
+                            arg2: std::os::raw::c_int,
+                            arg3: std::os::raw::c_int,
+                            arg4: std::os::raw::c_int,
+                            arg5: std::os::raw::c_int,
+                            arg6: std::os::raw::c_int,
+                            arg7: std::os::raw::c_int,
+                            data: *mut std::os::raw::c_void,
                         ) {
                             let mut wid = $name::from_widget_ptr(wid as *mut _);
-                            let ctx: TableContext = mem::transmute(ctx);
+                            let ctx: TableContext = std::mem::transmute(ctx);
                             let a: *mut Box<
                                 dyn FnMut(
                                     &mut $name,
-                                    crate::table::TableContext,
+                                    $crate::table::TableContext,
                                     i32,
                                     i32,
                                     i32,
@@ -449,7 +449,7 @@ macro_rules! impl_table_ext {
                             > = data as *mut Box<
                                 dyn FnMut(
                                     &mut $name,
-                                    crate::table::TableContext,
+                                    $crate::table::TableContext,
                                     i32,
                                     i32,
                                     i32,
@@ -460,7 +460,7 @@ macro_rules! impl_table_ext {
                             >;
                             let f: &mut (dyn FnMut(
                                 &mut $name,
-                                crate::table::TableContext,
+                                $crate::table::TableContext,
                                 i32,
                                 i32,
                                 i32,
@@ -476,7 +476,7 @@ macro_rules! impl_table_ext {
                         let a: *mut Box<
                             dyn FnMut(
                                 &mut Self,
-                                crate::table::TableContext,
+                                $crate::table::TableContext,
                                 i32,
                                 i32,
                                 i32,
@@ -485,7 +485,7 @@ macro_rules! impl_table_ext {
                                 i32,
                             ),
                         > = Box::into_raw(Box::new(Box::new(cb)));
-                        let data: *mut raw::c_void = a as *mut raw::c_void;
+                        let data: *mut std::os::raw::c_void = a as *mut std::os::raw::c_void;
                         let callback: CustomDrawCellCallback = Some(shim);
                         [<$flname _draw_cell>](self.inner, callback, data);
                     }
@@ -511,26 +511,26 @@ macro_rules! impl_table_ext {
                 }
 
                 fn callback_context(&self) -> TableContext {
-                    unsafe { mem::transmute([<$flname _callback_context>](self.inner)) }
+                    unsafe { std::mem::transmute([<$flname _callback_context>](self.inner)) }
                 }
 
-                fn scrollbar(&self) -> crate::valuator::Scrollbar {
+                fn scrollbar(&self) -> $crate::valuator::Scrollbar {
                     assert!(!self.was_deleted());
                     unsafe {
                         let ptr = [<$flname _scrollbar>](self.inner);
                         assert!(!ptr.is_null());
-                        crate::valuator::Scrollbar::from_widget_ptr(
+                        $crate::valuator::Scrollbar::from_widget_ptr(
                             ptr as *mut fltk_sys::widget::Fl_Widget,
                         )
                     }
                 }
 
-                fn hscrollbar(&self) -> crate::valuator::Scrollbar {
+                fn hscrollbar(&self) -> $crate::valuator::Scrollbar {
                     assert!(!self.was_deleted());
                     unsafe {
                         let ptr = [<$flname _hscrollbar>](self.inner);
                         assert!(!ptr.is_null());
-                        crate::valuator::Scrollbar::from_widget_ptr(
+                        $crate::valuator::Scrollbar::from_widget_ptr(
                             ptr as *mut fltk_sys::widget::Fl_Widget,
                         )
                     }

--- a/fltk/src/macros/valuator.rs
+++ b/fltk/src/macros/valuator.rs
@@ -88,7 +88,7 @@ macro_rules! impl_valuator_ext {
                         let arg2 = CString::safe_new(arg2);
                         let x = [<$flname _format>](
                             self.inner,
-                            arg2.as_ptr() as *mut raw::c_char,
+                            arg2.as_ptr() as *mut std::os::raw::c_char,
                         );
                         if x < 0 {
                             return Err(FltkError::Internal(FltkErrorKind::FailedOperation));

--- a/fltk/src/macros/widget.rs
+++ b/fltk/src/macros/widget.rs
@@ -51,7 +51,7 @@ macro_rules! impl_widget_ext {
                     self
                 }
 
-                fn with_align(mut self, align: Align) -> Self {
+                fn with_align(mut self, align: $crate::enums::Align) -> Self {
                     self.set_align(align);
                     self
                 }
@@ -285,7 +285,7 @@ macro_rules! impl_widget_ext {
                     assert!(!self.was_deleted());
                     unsafe {
                         fltk_sys::fl::Fl_lock();
-                        let ptr = [<$flname _label>](self.inner) as *mut raw::c_char;
+                        let ptr = [<$flname _label>](self.inner) as *mut std::os::raw::c_char;
                         let s = if ptr.is_null() {
                             String::from("")
                         } else {
@@ -344,7 +344,7 @@ macro_rules! impl_widget_ext {
                             None
                         } else {
                             Some(
-                                CStr::from_ptr(tooltip_ptr as *mut raw::c_char)
+                                CStr::from_ptr(tooltip_ptr as *mut std::os::raw::c_char)
                                     .to_string_lossy()
                                     .to_string(),
                             )
@@ -360,39 +360,39 @@ macro_rules! impl_widget_ext {
                     unsafe {
                         [<$flname _set_tooltip>](
                             self.inner,
-                            txt.as_ptr() as *mut raw::c_char,
+                            txt.as_ptr() as *mut std::os::raw::c_char,
                         )
                     }
                 }
 
-                fn color(&self) -> Color {
+                fn color(&self) -> $crate::enums::Color {
                     assert!(!self.was_deleted());
-                    unsafe { mem::transmute([<$flname _color>](self.inner)) }
+                    unsafe { std::mem::transmute([<$flname _color>](self.inner)) }
                 }
 
-                fn set_color(&mut self, color: Color) {
+                fn set_color(&mut self, color: $crate::enums::Color) {
                     assert!(!self.was_deleted());
                     unsafe { [<$flname _set_color>](self.inner, color.bits() as u32) }
                 }
 
-                fn label_color(&self) -> Color {
+                fn label_color(&self) -> $crate::enums::Color {
                     assert!(!self.was_deleted());
-                    unsafe { mem::transmute([<$flname _label_color>](self.inner)) }
+                    unsafe { std::mem::transmute([<$flname _label_color>](self.inner)) }
                 }
 
-                fn set_label_color(&mut self, color: Color) {
+                fn set_label_color(&mut self, color: $crate::enums::Color) {
                     assert!(!self.was_deleted());
                     unsafe {
                         [<$flname _set_label_color>](self.inner, color.bits() as u32)
                     }
                 }
 
-                fn label_font(&self) -> Font {
+                fn label_font(&self) -> $crate::enums::Font {
                     assert!(!self.was_deleted());
-                    unsafe { mem::transmute([<$flname _label_font>](self.inner)) }
+                    unsafe { std::mem::transmute([<$flname _label_font>](self.inner)) }
                 }
 
-                fn set_label_font(&mut self, font: Font) {
+                fn set_label_font(&mut self, font: $crate::enums::Font) {
                     assert!(!self.was_deleted());
                     unsafe { [<$flname _set_label_font>](self.inner, font.bits() as i32) }
                 }
@@ -408,24 +408,24 @@ macro_rules! impl_widget_ext {
                     unsafe { [<$flname _set_label_size>](self.inner, sz) }
                 }
 
-                fn label_type(&self) -> LabelType {
+                fn label_type(&self) -> $crate::enums::LabelType {
                     assert!(!self.was_deleted());
-                    unsafe { mem::transmute([<$flname _label_type>](self.inner)) }
+                    unsafe { std::mem::transmute([<$flname _label_type>](self.inner)) }
                 }
 
-                fn set_label_type(&mut self, typ: LabelType) {
+                fn set_label_type(&mut self, typ: $crate::enums::LabelType) {
                     assert!(!self.was_deleted());
                     unsafe {
                         [<$flname _set_label_type>](self.inner, typ as i32);
                     }
                 }
 
-                fn frame(&self) -> FrameType {
+                fn frame(&self) -> $crate::enums::FrameType {
                     assert!(!self.was_deleted());
-                    unsafe { mem::transmute([<$flname _box>](self.inner)) }
+                    unsafe { std::mem::transmute([<$flname _box>](self.inner)) }
                 }
 
-                fn set_frame(&mut self, typ: FrameType) {
+                fn set_frame(&mut self, typ: $crate::enums::FrameType) {
                     assert!(!self.was_deleted());
                     unsafe {
                         [<$flname _set_box>](self.inner, typ as i32);
@@ -447,44 +447,44 @@ macro_rules! impl_widget_ext {
                     unsafe { [<$flname _clear_changed>](self.inner) }
                 }
 
-                fn align(&self) -> Align {
+                fn align(&self) -> $crate::enums::Align {
                     assert!(!self.was_deleted());
-                    unsafe { mem::transmute([<$flname _align>](self.inner)) }
+                    unsafe { std::mem::transmute([<$flname _align>](self.inner)) }
                 }
 
-                fn set_align(&mut self, align: Align) {
+                fn set_align(&mut self, align: $crate::enums::Align) {
                     assert!(!self.was_deleted());
                     unsafe { [<$flname _set_align>](self.inner, align.bits() as i32) }
                 }
 
-                fn set_trigger(&mut self, trigger: CallbackTrigger) {
+                fn set_trigger(&mut self, trigger: $crate::enums::CallbackTrigger) {
                     assert!(!self.was_deleted());
                     unsafe { [<$flname _set_when>](self.inner, trigger.bits() as i32) }
                 }
 
-                fn trigger(&self) -> CallbackTrigger {
+                fn trigger(&self) -> $crate::enums::CallbackTrigger {
                     assert!(!self.was_deleted());
-                    unsafe { mem::transmute([<$flname _when>](self.inner)) }
+                    unsafe { std::mem::transmute([<$flname _when>](self.inner)) }
                 }
 
-                fn parent(&self) -> Option<crate::group::Group> {
+                fn parent(&self) -> Option<$crate::group::Group> {
                     assert!(!self.was_deleted());
                     unsafe {
                         let x = [<$flname _parent>](self.inner);
                         if x.is_null() {
                             None
                         } else {
-                            Some(crate::group::Group::from_widget_ptr(x as *mut _))
+                            Some($crate::group::Group::from_widget_ptr(x as *mut _))
                         }
                     }
                 }
 
-                fn selection_color(&mut self) -> Color {
+                fn selection_color(&mut self) -> $crate::enums::Color {
                     assert!(!self.was_deleted());
-                    unsafe { mem::transmute([<$flname _selection_color>](self.inner)) }
+                    unsafe { std::mem::transmute([<$flname _selection_color>](self.inner)) }
                 }
 
-                fn set_selection_color(&mut self, color: Color) {
+                fn set_selection_color(&mut self, color: $crate::enums::Color) {
                     assert!(!self.was_deleted());
                     unsafe {
                         [<$flname _set_selection_color>](self.inner, color.bits() as u32);
@@ -505,7 +505,7 @@ macro_rules! impl_widget_ext {
                         if wind_ptr.is_null() {
                             None
                         } else {
-                            Some(Box::new(Window::from_widget_ptr(
+                            Some(Box::new($crate::window::Window::from_widget_ptr(
                                 wind_ptr as *mut fltk_sys::widget::Fl_Widget,
                             )))
                         }
@@ -519,7 +519,7 @@ macro_rules! impl_widget_ext {
                         if wind_ptr.is_null() {
                             None
                         } else {
-                            Some(Box::new(Window::from_widget_ptr(
+                            Some(Box::new($crate::window::Window::from_widget_ptr(
                                 wind_ptr as *mut fltk_sys::widget::Fl_Widget,
                             )))
                         }
@@ -605,12 +605,12 @@ macro_rules! impl_widget_ext {
                     unsafe { [<$flname _set_damage>](self.inner, flag) }
                 }
 
-                fn damage_type(&self) -> Damage {
+                fn damage_type(&self) -> $crate::enums::Damage {
                     assert!(!self.was_deleted());
-                    unsafe { mem::transmute([<$flname _damage>](self.inner)) }
+                    unsafe { std::mem::transmute([<$flname _damage>](self.inner)) }
                 }
 
-                fn set_damage_type(&mut self, mask: Damage) {
+                fn set_damage_type(&mut self, mask: $crate::enums::Damage) {
                     assert!(!self.was_deleted());
                     unsafe { [<$flname _set_damage>](self.inner, mask.bits()) }
                 }
@@ -627,20 +627,20 @@ macro_rules! impl_widget_ext {
                         if ptr.is_null() {
                             return None;
                         }
-                        Some(Box::new(Window::from_widget_ptr(
+                        Some(Box::new($crate::window::Window::from_widget_ptr(
                             ptr as *mut fltk_sys::widget::Fl_Widget,
                         )))
                     }
                 }
 
-                fn as_group(&self) -> Option<crate::group::Group> {
+                fn as_group(&self) -> Option<$crate::group::Group> {
                     assert!(!self.was_deleted());
                     unsafe {
                         let ptr = [<$flname _as_group>](self.inner);
                         if ptr.is_null() {
                             return None;
                         }
-                        Some(crate::group::Group::from_widget_ptr(
+                        Some($crate::group::Group::from_widget_ptr(
                             ptr as *mut fltk_sys::widget::Fl_Widget,
                         ))
                     }
@@ -652,7 +652,7 @@ macro_rules! impl_widget_ext {
                     unsafe {
                         [<$flname _inside>](
                             self.inner,
-                            wid.as_widget_ptr() as *mut raw::c_void,
+                            wid.as_widget_ptr() as *mut std::os::raw::c_void,
                         ) != 0
                     }
                 }
@@ -683,7 +683,7 @@ macro_rules! impl_widget_ext {
                         unsafe {
                             [<$flname _set_image>](
                                 self.inner,
-                                std::ptr::null_mut() as *mut raw::c_void,
+                                std::ptr::null_mut() as *mut std::os::raw::c_void,
                             )
                         }
                     }
@@ -704,7 +704,7 @@ macro_rules! impl_widget_ext {
                         unsafe {
                             [<$flname _set_image>](
                                 self.inner,
-                                std::ptr::null_mut() as *mut raw::c_void,
+                                std::ptr::null_mut() as *mut std::os::raw::c_void,
                             )
                         }
                     }
@@ -718,7 +718,7 @@ macro_rules! impl_widget_ext {
                             None
                         } else {
                             let img =
-                                Image::from_image_ptr(image_ptr as *mut fltk_sys::image::Fl_Image);
+                            $crate::image::Image::from_image_ptr(image_ptr as *mut fltk_sys::image::Fl_Image);
                             Some(Box::new(img))
                         }
                     }
@@ -738,7 +738,7 @@ macro_rules! impl_widget_ext {
                         unsafe {
                             [<$flname _set_deimage>](
                                 self.inner,
-                                std::ptr::null_mut() as *mut raw::c_void,
+                                std::ptr::null_mut() as *mut std::os::raw::c_void,
                             )
                         }
                     }
@@ -759,7 +759,7 @@ macro_rules! impl_widget_ext {
                         unsafe {
                             [<$flname _set_deimage>](
                                 self.inner,
-                                std::ptr::null_mut() as *mut raw::c_void,
+                                std::ptr::null_mut() as *mut std::os::raw::c_void,
                             )
                         }
                     }
@@ -773,7 +773,7 @@ macro_rules! impl_widget_ext {
                             None
                         } else {
                             let img =
-                                Image::from_image_ptr(image_ptr as *mut fltk_sys::image::Fl_Image);
+                            $crate::image::Image::from_image_ptr(image_ptr as *mut fltk_sys::image::Fl_Image);
                             Some(Box::new(img))
                         }
                     }
@@ -782,7 +782,7 @@ macro_rules! impl_widget_ext {
                 fn set_callback<F: FnMut(&mut Self) + 'static>(&mut self, cb: F) {
                     assert!(!self.was_deleted());
                     unsafe {
-                        unsafe extern "C" fn shim(wid: *mut Fl_Widget, data: *mut raw::c_void) {
+                        unsafe extern "C" fn shim(wid: *mut Fl_Widget, data: *mut std::os::raw::c_void) {
                             let mut wid = $name::from_widget_ptr(wid as *mut _);
                             let a = data as *mut Box<dyn FnMut(&mut $name)>;
                             let f: &mut (dyn FnMut(&mut $name)) = &mut **a;
@@ -791,7 +791,7 @@ macro_rules! impl_widget_ext {
                         }
                         let _old_data = self.user_data();
                         let a: *mut Box<dyn FnMut(&mut Self)> = Box::into_raw(Box::new(Box::new(cb)));
-                        let data: *mut raw::c_void = a as *mut raw::c_void;
+                        let data: *mut std::os::raw::c_void = a as *mut std::os::raw::c_void;
                         let callback: Fl_Callback = Some(shim);
                         [<$flname _set_callback>](self.inner, callback, data);
                     }
@@ -799,7 +799,7 @@ macro_rules! impl_widget_ext {
 
                 fn emit<T: 'static + Clone + Send + Sync>(
                     &mut self,
-                    sender: crate::app::Sender<T>,
+                    sender: $crate::app::Sender<T>,
                     msg: T,
                 ) {
                     assert!(!self.was_deleted());
@@ -854,7 +854,7 @@ macro_rules! impl_widget_ext {
                     }
                 }
 
-                fn handle_event(&mut self, event: Event) {
+                fn handle_event(&mut self, event: $crate::enums::Event) {
                     assert!(!self.was_deleted());
                     unsafe { [<$flname _handle_event>](self.inner, event.bits()) }
                 }
@@ -894,7 +894,7 @@ macro_rules! impl_widget_base {
                             widget_ptr as *mut fltk_sys::fl::Fl_Widget,
                         );
                         assert!(!tracker.is_null());
-                        unsafe extern "C" fn shim(data: *mut raw::c_void) {
+                        unsafe extern "C" fn shim(data: *mut std::os::raw::c_void) {
                             if !data.is_null() {
                                 let x = data as *mut Box<dyn FnMut()>;
                                 let _x = Box::from_raw(x);
@@ -946,20 +946,20 @@ macro_rules! impl_widget_base {
                     Self::from_widget_ptr(w.as_widget_ptr() as *mut _)
                 }
 
-                fn handle<F: FnMut(&mut Self, Event) -> bool + 'static>(&mut self, cb: F) {
+                fn handle<F: FnMut(&mut Self, $crate::enums::Event) -> bool + 'static>(&mut self, cb: F) {
                     assert!(!self.was_deleted());
                     assert!(self.is_derived);
                     unsafe {
                         unsafe extern "C" fn shim(
                             wid: *mut Fl_Widget,
                             ev: std::os::raw::c_int,
-                            data: *mut raw::c_void,
+                            data: *mut std::os::raw::c_void,
                         ) -> i32 {
                             let mut wid = $name::from_widget_ptr(wid as *mut _);
-                            let ev: Event = mem::transmute(ev);
-                            let a: *mut Box<dyn FnMut(&mut $name, Event) -> bool> =
-                                data as *mut Box<dyn FnMut(&mut $name, Event) -> bool>;
-                            let f: &mut (dyn FnMut(&mut $name, Event) -> bool) = &mut **a;
+                            let ev: $crate::enums::Event = std::mem::transmute(ev);
+                            let a: *mut Box<dyn FnMut(&mut $name, $crate::enums::Event) -> bool> =
+                                data as *mut Box<dyn FnMut(&mut $name, $crate::enums::Event) -> bool>;
+                            let f: &mut (dyn FnMut(&mut $name, $crate::enums::Event) -> bool) = &mut **a;
                             let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                                 match f(&mut wid, ev) {
                                     true => return 1,
@@ -973,9 +973,9 @@ macro_rules! impl_widget_base {
                             }
                         }
                         let _old_data = self.handle_data();
-                        let a: *mut Box<dyn FnMut(&mut Self, Event) -> bool> =
+                        let a: *mut Box<dyn FnMut(&mut Self, $crate::enums::Event) -> bool> =
                             Box::into_raw(Box::new(Box::new(cb)));
-                        let data: *mut raw::c_void = a as *mut raw::c_void;
+                        let data: *mut std::os::raw::c_void = a as *mut std::os::raw::c_void;
                         let callback: custom_handler_callback = Some(shim);
                         [<$flname _handle>](self.inner, callback, data);
                     }
@@ -985,7 +985,7 @@ macro_rules! impl_widget_base {
                     assert!(!self.was_deleted());
                     assert!(self.is_derived);
                     unsafe {
-                        unsafe extern "C" fn shim(wid: *mut Fl_Widget, data: *mut raw::c_void) {
+                        unsafe extern "C" fn shim(wid: *mut Fl_Widget, data: *mut std::os::raw::c_void) {
                             let mut wid = $name::from_widget_ptr(wid as *mut _);
                             let a: *mut Box<dyn FnMut(&mut $name)> =
                                 data as *mut Box<dyn FnMut(&mut $name)>;
@@ -995,7 +995,7 @@ macro_rules! impl_widget_base {
                         }
                         let _old_data = self.draw_data();
                         let a: *mut Box<dyn FnMut(&mut Self)> = Box::into_raw(Box::new(Box::new(cb)));
-                        let data: *mut raw::c_void = a as *mut raw::c_void;
+                        let data: *mut std::os::raw::c_void = a as *mut std::os::raw::c_void;
                         let callback: custom_draw_callback = Some(shim);
                         [<$flname _draw>](self.inner, callback, data);
                     }
@@ -1012,12 +1012,12 @@ macro_rules! impl_widget_base {
                     Some(*data)
                 }
 
-                unsafe fn handle_data(&mut self) -> Option<Box<dyn FnMut(Event) -> bool>> {
+                unsafe fn handle_data(&mut self) -> Option<Box<dyn FnMut($crate::enums::Event) -> bool>> {
                     let ptr = [<$flname _handle_data>](self.inner);
                     if ptr.is_null() {
                         return None;
                     }
-                    let data = ptr as *mut Box<dyn FnMut(Event) -> bool>;
+                    let data = ptr as *mut Box<dyn FnMut($crate::enums::Event) -> bool>;
                     let data = Box::from_raw(data);
                     [<$flname _handle>](self.inner, None, std::ptr::null_mut());
                     Some(*data)
@@ -1036,7 +1036,7 @@ macro_rules! impl_widget_base {
                             y: i32,
                             w: i32,
                             h: i32,
-                            data: *mut raw::c_void,
+                            data: *mut std::os::raw::c_void,
                         ) {
                             let mut wid = $name::from_widget_ptr(wid as *mut _);
                             let a: *mut Box<dyn FnMut(&mut $name, i32, i32, i32, i32)> =
@@ -1048,9 +1048,9 @@ macro_rules! impl_widget_base {
                         }
                         let a: *mut Box<dyn FnMut(&mut Self, i32, i32, i32, i32)> =
                             Box::into_raw(Box::new(Box::new(cb)));
-                        let data: *mut raw::c_void = a as *mut raw::c_void;
+                        let data: *mut std::os::raw::c_void = a as *mut std::os::raw::c_void;
                         let callback: Option<
-                            unsafe extern "C" fn(*mut Fl_Widget, i32, i32, i32, i32, *mut raw::c_void),
+                            unsafe extern "C" fn(*mut Fl_Widget, i32, i32, i32, i32, *mut std::os::raw::c_void),
                         > = Some(shim);
                         [<$flname _resize_callback>](self.inner, callback, data);
                     }
@@ -1070,7 +1070,7 @@ macro_rules! impl_widget_type {
             }
 
             fn from_i32(val: i32) -> $name {
-                unsafe { mem::transmute(val) }
+                unsafe { std::mem::transmute(val) }
             }
         }
     };
@@ -1079,7 +1079,6 @@ macro_rules! impl_widget_type {
 pub use impl_widget_base;
 pub use impl_widget_ext;
 pub use impl_widget_type;
-
 
 #[macro_export]
 /// Implements WidgetExt via a member
@@ -1101,7 +1100,7 @@ macro_rules! impl_widget_ext_via {
                 self
             }
 
-            fn with_align(mut self, align: Align) -> Self {
+            fn with_align(mut self, align: $crate::enums::Align) -> Self {
                 self.$member = self.$member.with_align(align);
                 self
             }
@@ -1217,7 +1216,7 @@ macro_rules! impl_widget_ext_via {
                 self.$member.measure_label()
             }
 
-            unsafe fn as_widget_ptr(&self) -> crate::app::WidgetPtr {
+            unsafe fn as_widget_ptr(&self) -> $crate::app::WidgetPtr {
                 self.$member.as_widget_ptr()
             }
 
@@ -1266,7 +1265,7 @@ macro_rules! impl_widget_ext_via {
 
             fn emit<T: 'static + Clone + Send + Sync>(
                 &mut self,
-                sender: crate::app::Sender<T>,
+                sender: $crate::app::Sender<T>,
                 msg: T,
             ) {
                 self.$member.emit(sender, msg)
@@ -1296,27 +1295,27 @@ macro_rules! impl_widget_ext_via {
                 self.$member.set_tooltip(txt)
             }
 
-            fn color(&self) -> Color {
+            fn color(&self) -> $crate::enums::Color {
                 self.$member.color()
             }
 
-            fn set_color(&mut self, color: Color) {
+            fn set_color(&mut self, color: $crate::enums::Color) {
                 self.$member.set_color(color)
             }
 
-            fn label_color(&self) -> Color {
+            fn label_color(&self) -> $crate::enums::Color {
                 self.$member.label_color()
             }
 
-            fn set_label_color(&mut self, color: Color) {
+            fn set_label_color(&mut self, color: $crate::enums::Color) {
                 self.$member.set_label_color(color)
             }
 
-            fn label_font(&self) -> Font {
+            fn label_font(&self) -> $crate::enums::Font {
                 self.$member.label_font()
             }
 
-            fn set_label_font(&mut self, font: Font) {
+            fn set_label_font(&mut self, font: $crate::enums::Font) {
                 self.$member.set_label_font(font)
             }
 
@@ -1328,19 +1327,19 @@ macro_rules! impl_widget_ext_via {
                 self.$member.set_label_size(sz)
             }
 
-            fn label_type(&self) -> LabelType {
+            fn label_type(&self) -> $crate::enums::LabelType {
                 self.$member.label_type()
             }
 
-            fn set_label_type(&mut self, typ: LabelType) {
+            fn set_label_type(&mut self, typ: $crate::enums::LabelType) {
                 self.$member.set_label_type(typ)
             }
 
-            fn frame(&self) -> FrameType {
+            fn frame(&self) -> $crate::enums::FrameType {
                 self.$member.frame()
             }
 
-            fn set_frame(&mut self, typ: FrameType) {
+            fn set_frame(&mut self, typ: $crate::enums::FrameType) {
                 self.$member.set_frame(typ)
             }
 
@@ -1356,23 +1355,23 @@ macro_rules! impl_widget_ext_via {
                 self.$member.clear_changed()
             }
 
-            fn align(&self) -> Align {
+            fn align(&self) -> $crate::enums::Align {
                 self.$member.align()
             }
 
-            fn set_align(&mut self, align: Align) {
+            fn set_align(&mut self, align: $crate::enums::Align) {
                 self.$member.set_align(align)
             }
 
-            fn parent(&self) -> Option<crate::group::Group> {
+            fn parent(&self) -> Option<$crate::group::Group> {
                 self.$member.parent()
             }
 
-            fn selection_color(&mut self) -> Color {
+            fn selection_color(&mut self) -> $crate::enums::Color {
                 self.$member.selection_color()
             }
 
-            fn set_selection_color(&mut self, color: Color) {
+            fn set_selection_color(&mut self, color: $crate::enums::Color) {
                 self.$member.set_selection_color(color)
             }
 
@@ -1428,11 +1427,11 @@ macro_rules! impl_widget_ext_via {
                 self.$member.set_damage(flag)
             }
 
-            fn damage_type(&self) -> Damage {
+            fn damage_type(&self) -> $crate::enums::Damage {
                 self.$member.damage_type()
             }
 
-            fn set_damage_type(&mut self, mask: Damage) {
+            fn set_damage_type(&mut self, mask: $crate::enums::Damage) {
                 self.$member.set_damage_type(mask)
             }
 
@@ -1440,11 +1439,11 @@ macro_rules! impl_widget_ext_via {
                 self.$member.clear_damage()
             }
 
-            fn set_trigger(&mut self, trigger: CallbackTrigger) {
+            fn set_trigger(&mut self, trigger: $crate::enums::CallbackTrigger) {
                 self.$member.set_trigger(trigger)
             }
 
-            fn trigger(&self) -> CallbackTrigger {
+            fn trigger(&self) -> $crate::enums::CallbackTrigger {
                 self.$member.trigger()
             }
 
@@ -1452,7 +1451,7 @@ macro_rules! impl_widget_ext_via {
                 self.$member.as_window()
             }
 
-            fn as_group(&self) -> Option<crate::group::Group> {
+            fn as_group(&self) -> Option<$crate::group::Group> {
                 self.$member.as_group()
             }
 
@@ -1500,7 +1499,7 @@ macro_rules! impl_widget_ext_via {
                 self.$member.widget_resize(x, y, w, h)
             }
 
-            fn handle_event(&mut self, event: Event) {
+            fn handle_event(&mut self, event: $crate::enums::Event) {
                 self.$member.handle_event(event)
             }
         }
@@ -1510,7 +1509,7 @@ macro_rules! impl_widget_ext_via {
 #[macro_export]
 /// Implements WidgetBase via a member
 macro_rules! impl_widget_base_via {
-    ($widget:ty, $base:ty, $member:tt) => {        
+    ($widget:ty, $base:ty, $member:tt) => {
         unsafe impl WidgetBase for $widget {
             fn new<T: Into<Option<&'static str>>>(
                 x: i32,
@@ -1527,14 +1526,16 @@ macro_rules! impl_widget_base_via {
             }
 
             fn default_fill() -> Self {
-                Self::new(0, 0, 0, 0, None).size_of_parent().center_of_parent()
+                Self::new(0, 0, 0, 0, None)
+                    .size_of_parent()
+                    .center_of_parent()
             }
 
             fn delete(wid: Self) {
                 <$base>::delete(wid.$member)
             }
 
-            unsafe fn from_widget_ptr(ptr: crate::app::WidgetPtr) -> Self {
+            unsafe fn from_widget_ptr(ptr: $crate::app::WidgetPtr) -> Self {
                 let $member = <$base>::from_widget_ptr(ptr);
                 Self {
                     $member,
@@ -1550,7 +1551,10 @@ macro_rules! impl_widget_base_via {
                 }
             }
 
-            fn handle<F: FnMut(&mut Self, Event) -> bool + 'static>(&mut self, mut cb: F) {
+            fn handle<F: FnMut(&mut Self, $crate::enums::Event) -> bool + 'static>(
+                &mut self,
+                mut cb: F,
+            ) {
                 let mut widget = self.clone();
                 self.$member.handle(move |_, ev| cb(&mut widget, ev));
             }
@@ -1564,17 +1568,23 @@ macro_rules! impl_widget_base_via {
                 self.$member.draw_data()
             }
 
-            unsafe fn handle_data(&mut self) -> Option<Box<dyn FnMut(Event) -> bool>> {
+            unsafe fn handle_data(
+                &mut self,
+            ) -> Option<Box<dyn FnMut($crate::enums::Event) -> bool>> {
                 self.$member.handle_data()
             }
 
-            fn resize_callback<F: FnMut(&mut Self, i32, i32, i32, i32) + 'static>(&mut self, mut cb: F) {
+            fn resize_callback<F: FnMut(&mut Self, i32, i32, i32, i32) + 'static>(
+                &mut self,
+                mut cb: F,
+            ) {
                 let mut widget = self.clone();
-                self.$member.resize_callback(move |_, x, y, w, h| cb(&mut widget, x, y, w, h))
+                self.$member
+                    .resize_callback(move |_, x, y, w, h| cb(&mut widget, x, y, w, h))
             }
         }
     };
 }
 
-pub use impl_widget_ext_via;
 pub use impl_widget_base_via;
+pub use impl_widget_ext_via;

--- a/fltk/src/macros/window.rs
+++ b/fltk/src/macros/window.rs
@@ -9,7 +9,7 @@ macro_rules! impl_window_ext {
                 {
                     return RawWindowHandle::Windows(windows::WindowsHandle {
                         hwnd: self.raw_handle(),
-                        hinstance: crate::app::display(),
+                        hinstance: $crate::app::display(),
                         ..windows::WindowsHandle::empty()
                     });
                 }
@@ -46,7 +46,7 @@ macro_rules! impl_window_ext {
                 {
                     return RawWindowHandle::Xlib(unix::XlibHandle {
                         window: self.raw_handle(),
-                        display: crate::app::display(),
+                        display: $crate::app::display(),
                         ..unix::XlibHandle::empty()
                     });
                 }
@@ -54,7 +54,7 @@ macro_rules! impl_window_ext {
                 // {
                 //     let mut handle = Win32Handle::empty();
                 //     handle.hwnd = self.raw_handle();
-                //     handle.hinstance = crate::app::display();
+                //     handle.hinstance = $crate::app::display();
                 //     return RawWindowHandle::Win32(handle);
                 // }
 
@@ -88,7 +88,7 @@ macro_rules! impl_window_ext {
                 // {
                 //     let mut handle = XlibHandle::empty();
                 //     handle.window = self.raw_handle();
-                //     handle.display = crate::app::display();
+                //     handle.display = $crate::app::display();
                 //     return RawWindowHandle::Xlib(handle);
                 // }
             }
@@ -137,7 +137,7 @@ macro_rules! impl_window_ext {
                             None
                         } else {
                             let img =
-                                Image::from_image_ptr(image_ptr as *mut fltk_sys::image::Fl_Image);
+                            $crate::image::Image::from_image_ptr(image_ptr as *mut fltk_sys::image::Fl_Image);
                             Some(Box::new(img))
                         }
                     }
@@ -147,40 +147,40 @@ macro_rules! impl_window_ext {
                     assert!(!self.was_deleted());
                     assert!(
                         std::any::type_name::<T>()
-                            != std::any::type_name::<crate::image::SharedImage>(),
+                            != std::any::type_name::<$crate::image::SharedImage>(),
                         "SharedImage icons are not supported!"
                     );
                     assert!(
-                        std::any::type_name::<T>() != std::any::type_name::<crate::image::Pixmap>(),
+                        std::any::type_name::<T>() != std::any::type_name::<$crate::image::Pixmap>(),
                         "Pixmap icons are not supported!"
                     );
                     assert!(
-                        std::any::type_name::<T>() != std::any::type_name::<crate::image::XpmImage>(),
+                        std::any::type_name::<T>() != std::any::type_name::<$crate::image::XpmImage>(),
                         "Xpm icons are not supported!"
                     );
                     assert!(
-                        std::any::type_name::<T>() != std::any::type_name::<crate::image::XbmImage>(),
+                        std::any::type_name::<T>() != std::any::type_name::<$crate::image::XbmImage>(),
                         "Xbm icons are not supported!"
                     );
                     assert!(
-                        std::any::type_name::<T>() != std::any::type_name::<crate::image::PnmImage>(),
+                        std::any::type_name::<T>() != std::any::type_name::<$crate::image::PnmImage>(),
                         "Pnm icons are not supported!"
                     );
                     assert!(
-                        std::any::type_name::<T>() != std::any::type_name::<crate::image::GifImage>(),
+                        std::any::type_name::<T>() != std::any::type_name::<$crate::image::GifImage>(),
                         "Gif icons are not supported!"
                     );
                     assert!(
-                        std::any::type_name::<T>() != std::any::type_name::<crate::image::Image>(),
+                        std::any::type_name::<T>() != std::any::type_name::<$crate::image::Image>(),
                         "Icon images can't be generic!"
                     );
                     assert!(
-                        std::any::type_name::<T>() != std::any::type_name::<crate::image::TiledImage>(),
+                        std::any::type_name::<T>() != std::any::type_name::<$crate::image::TiledImage>(),
                         "TiledImage icons are not supported!"
                     );
                     if let Some(mut image) = image {
                         assert!(!image.was_deleted());
-                        if std::any::type_name::<T>() == std::any::type_name::<crate::image::SvgImage>()
+                        if std::any::type_name::<T>() == std::any::type_name::<$crate::image::SvgImage>()
                         {
                             unsafe {
                                 image.increment_arc();
@@ -282,7 +282,7 @@ macro_rules! impl_window_ext {
                     Fl_Window_set_raw_handle(self.inner as *mut Fl_Window, mem::transmute(&handle));
                 }
 
-                fn region(&self) -> crate::draw::Region {
+                fn region(&self) -> $crate::draw::Region {
                     assert!(!self.was_deleted());
                     unsafe {
                         let ptr = [<$flname _region>](self.inner);
@@ -291,7 +291,7 @@ macro_rules! impl_window_ext {
                     }
                 }
 
-                unsafe fn set_region(&mut self, region: crate::draw::Region) {
+                unsafe fn set_region(&mut self, region: $crate::draw::Region) {
                     assert!(!self.was_deleted());
                     assert!(!region.is_null());
                     [<$flname _set_region>](self.inner, region)
@@ -336,39 +336,39 @@ macro_rules! impl_window_ext {
                     assert!(self.h() != 0);
                     assert!(
                         std::any::type_name::<I>()
-                            != std::any::type_name::<crate::image::SharedImage>(),
+                            != std::any::type_name::<$crate::image::SharedImage>(),
                         "SharedImage is not supported!"
                     );
                     assert!(
-                        std::any::type_name::<I>() != std::any::type_name::<crate::image::XbmImage>(),
+                        std::any::type_name::<I>() != std::any::type_name::<$crate::image::XbmImage>(),
                         "Xbm is not supported!"
                     );
                     assert!(
-                        std::any::type_name::<I>() != std::any::type_name::<crate::image::PnmImage>(),
+                        std::any::type_name::<I>() != std::any::type_name::<$crate::image::PnmImage>(),
                         "Pnm is not supported!"
                     );
                     assert!(
-                        std::any::type_name::<I>() != std::any::type_name::<crate::image::GifImage>(),
+                        std::any::type_name::<I>() != std::any::type_name::<$crate::image::GifImage>(),
                         "Gif is not supported!"
                     );
                     assert!(
-                        std::any::type_name::<I>() != std::any::type_name::<crate::image::JpegImage>(),
+                        std::any::type_name::<I>() != std::any::type_name::<$crate::image::JpegImage>(),
                         "Jpeg is not supported!"
                     );
                     assert!(
-                        std::any::type_name::<I>() != std::any::type_name::<crate::image::SvgImage>(),
+                        std::any::type_name::<I>() != std::any::type_name::<$crate::image::SvgImage>(),
                         "Svg is not supported!"
                     );
                     assert!(
-                        std::any::type_name::<I>() != std::any::type_name::<crate::image::PngImage>(),
+                        std::any::type_name::<I>() != std::any::type_name::<$crate::image::PngImage>(),
                         "Png is not supported!"
                     );
                     assert!(
-                        std::any::type_name::<I>() != std::any::type_name::<crate::image::Image>(),
+                        std::any::type_name::<I>() != std::any::type_name::<$crate::image::Image>(),
                         "Images can't be generic!"
                     );
                     assert!(
-                        std::any::type_name::<I>() != std::any::type_name::<crate::image::TiledImage>(),
+                        std::any::type_name::<I>() != std::any::type_name::<$crate::image::TiledImage>(),
                         "TiledImage is not supported!"
                     );
                     unsafe {
@@ -389,7 +389,7 @@ macro_rules! impl_window_ext {
                             None
                         } else {
                             let img =
-                                Image::from_image_ptr(image_ptr as *mut fltk_sys::image::Fl_Image);
+                            $crate::image::Image::from_image_ptr(image_ptr as *mut fltk_sys::image::Fl_Image);
                             Some(Box::new(img))
                         }
                     }
@@ -407,7 +407,7 @@ macro_rules! impl_window_ext {
 
                 fn set_cursor_image(
                     &mut self,
-                    mut image: crate::image::RgbImage,
+                    mut image: $crate::image::RgbImage,
                     hot_x: i32,
                     hot_y: i32,
                 ) {

--- a/fltk/src/menu.rs
+++ b/fltk/src/menu.rs
@@ -1,10 +1,6 @@
-use crate::enums::{
-    Align, CallbackTrigger, Color, Damage, Event, Font, FrameType, LabelType, Shortcut,
-};
-use crate::image::Image;
+use crate::enums::{Color, Font, LabelType};
 use crate::prelude::*;
 use crate::utils::FlString;
-use crate::window::Window;
 use fltk_sys::menu::*;
 use std::{
     ffi::{CStr, CString},

--- a/fltk/src/misc.rs
+++ b/fltk/src/misc.rs
@@ -1,9 +1,8 @@
-use crate::enums::{Align, CallbackTrigger, Color, Damage, Event, Font, FrameType, LabelType};
-use crate::image::Image;
+use crate::enums::{Color, Font, FrameType};
 use crate::prelude::*;
 use crate::utils::FlString;
-use crate::window::Window;
 use crate::widget::Widget;
+use crate::window::Window;
 use fltk_sys::misc::*;
 use std::{
     ffi::{CStr, CString},

--- a/fltk/src/output.rs
+++ b/fltk/src/output.rs
@@ -1,14 +1,7 @@
-use crate::enums::{Align, CallbackTrigger, Color, Damage, Event, Font, FrameType, LabelType};
-use crate::image::Image;
 use crate::prelude::*;
 use crate::utils::FlString;
-use crate::window::Window;
 use fltk_sys::input::*;
-use std::{
-    ffi::{CStr, CString},
-    mem,
-    os::raw,
-};
+use std::ffi::{CStr, CString};
 
 /// Sets the input widget's type
 #[repr(i32)]

--- a/fltk/src/table.rs
+++ b/fltk/src/table.rs
@@ -1,15 +1,7 @@
-use crate::enums::{Align, CallbackTrigger, Color, Damage, Event, Font, FrameType, LabelType};
-use crate::image::Image;
 use crate::prelude::*;
 use crate::utils::FlString;
-use crate::window::Window;
-use crate::widget::Widget;
 use fltk_sys::table::*;
-use std::{
-    ffi::{CStr, CString},
-    mem,
-    os::raw,
-};
+use std::ffi::{CStr, CString};
 
 /// Creates a table
 /// For a simpler boilerplate-less table, check the [fltk-table crate](https://crates.io/crates/fltk-table)

--- a/fltk/src/text.rs
+++ b/fltk/src/text.rs
@@ -1,12 +1,9 @@
-use crate::enums::{Align, CallbackTrigger, Color, Damage, Event, Font, FrameType, Key, LabelType};
-use crate::image::Image;
+use crate::enums::{Color, Font, Key};
 use crate::prelude::*;
 use crate::utils::FlString;
-use crate::window::Window;
 use fltk_sys::text::*;
 use std::{
     ffi::{CStr, CString},
-    mem,
     os::raw,
     sync::atomic::{AtomicUsize, Ordering},
 };

--- a/fltk/src/tree.rs
+++ b/fltk/src/tree.rs
@@ -1,8 +1,7 @@
-use crate::enums::{Align, CallbackTrigger, Color, Damage, Event, Font, FrameType, Key, LabelType};
+use crate::enums::{Color, Font, FrameType, Key};
 use crate::image::Image;
 use crate::prelude::*;
 use crate::utils::FlString;
-use crate::window::Window;
 use crate::widget::Widget;
 use fltk_sys::tree::*;
 use std::{
@@ -1158,7 +1157,7 @@ impl Tree {
         unsafe {
             let ret = Fl_Tree_item_pathname(self.inner, temp.as_mut_ptr() as _, 256, item.inner);
             if ret == 0 {
-                if let Some(pos) =  temp.iter().position(|x| *x == 0) {
+                if let Some(pos) = temp.iter().position(|x| *x == 0) {
                     temp = temp.split_at(pos).0.to_vec();
                 }
                 Ok(String::from_utf8_lossy(&temp).to_string())
@@ -1410,14 +1409,14 @@ impl TreeItem {
         unsafe { mem::transmute(Fl_Tree_Item_labelfgcolor(self.inner)) }
     }
 
-    #[deprecated(since="1.2.19", note="please use `set_label_fgcolor` instead")]
+    #[deprecated(since = "1.2.19", note = "please use `set_label_fgcolor` instead")]
     /// Sets the label's foreground color
     pub fn set_label_fg_color(&mut self, val: Color) {
         assert!(!self.was_deleted());
         unsafe { Fl_Tree_Item_set_labelfgcolor(self.inner, val.bits() as u32) }
     }
 
-    #[deprecated(since="1.2.19", note="please use `label_fgcolor` instead")]
+    #[deprecated(since = "1.2.19", note = "please use `label_fgcolor` instead")]
     /// Gets the label's foreground color
     pub fn label_fg_color(&self) -> Color {
         assert!(!self.was_deleted());
@@ -1455,7 +1454,7 @@ impl TreeItem {
         unsafe { Fl_Tree_Item_set_widget(self.inner, val.as_widget_ptr() as *mut Fl_Widget) }
     }
 
-    #[deprecated(since="1.2.18", note="please use `try_widget` instead")]
+    #[deprecated(since = "1.2.18", note = "please use `try_widget` instead")]
     /// Gets the item's associated widget
     pub fn widget(&self) -> Widget {
         assert!(!self.was_deleted());

--- a/fltk/src/valuator.rs
+++ b/fltk/src/valuator.rs
@@ -1,8 +1,6 @@
-use crate::enums::{Align, CallbackTrigger, Color, Damage, Event, Font, FrameType, LabelType};
-use crate::image::Image;
+use crate::enums::{Color, Font, FrameType};
 use crate::prelude::*;
 use crate::utils::FlString;
-use crate::window::Window;
 use fltk_sys::valuator::*;
 use std::{
     ffi::{CStr, CString},

--- a/fltk/src/widget.rs
+++ b/fltk/src/widget.rs
@@ -1,12 +1,7 @@
-use crate::enums::{Align, CallbackTrigger, Color, Damage, Event, Font, FrameType, LabelType};
-use crate::image::Image;
 use crate::prelude::*;
 use crate::utils::FlString;
-use crate::window::Window;
 use fltk_sys::widget::*;
 use std::ffi::{CStr, CString};
-use std::mem;
-use std::os::raw;
 
 /// An abstract type, shouldn't be instantiated in user code
 #[derive(Debug)]

--- a/fltk/src/window.rs
+++ b/fltk/src/window.rs
@@ -230,11 +230,9 @@ impl SingleWindow {
     /// This should be called before showing with window
     pub fn set_default_xclass(s: &str) {
         let s = CString::safe_new(s);
-        unsafe {
-            Fl_Window_set_default_xclass(s.as_ptr())
-        }
+        unsafe { Fl_Window_set_default_xclass(s.as_ptr()) }
     }
-    
+
     /// Get the window's XA_WM_CLASS property
     pub fn xclass(&self) -> Option<String> {
         assert!(!self.was_deleted());
@@ -253,9 +251,7 @@ impl SingleWindow {
     pub fn set_xclass(&mut self, s: &str) {
         assert!(!self.was_deleted());
         let s = CString::safe_new(s);
-        unsafe {
-            Fl_Window_set_xclass(self.inner as _, s.as_ptr())
-        }
+        unsafe { Fl_Window_set_xclass(self.inner as _, s.as_ptr()) }
     }
 }
 
@@ -498,11 +494,9 @@ impl DoubleWindow {
     /// This should be called before showing with window
     pub fn set_default_xclass(s: &str) {
         let s = CString::safe_new(s);
-        unsafe {
-            Fl_Window_set_default_xclass(s.as_ptr())
-        }
+        unsafe { Fl_Window_set_default_xclass(s.as_ptr()) }
     }
-    
+
     /// Get the window's XA_WM_CLASS property
     pub fn xclass(&self) -> Option<String> {
         assert!(!self.was_deleted());
@@ -521,9 +515,7 @@ impl DoubleWindow {
     pub fn set_xclass(&mut self, s: &str) {
         assert!(!self.was_deleted());
         let s = CString::safe_new(s);
-        unsafe {
-            Fl_Window_set_xclass(self.inner as _, s.as_ptr())
-        }
+        unsafe { Fl_Window_set_xclass(self.inner as _, s.as_ptr()) }
     }
 }
 


### PR DESCRIPTION
This PR addresses #1027 and allows the macros to be use with greater flexibility by lowering the requirements for the call site environment. Also, since the macros are more self contained, I removed some of the boilerplate in the other source files.