### PR TITLE
1.2.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ## [1.2.20] - Unreleased
 - Update doc comment on draw::set_line_style().
+- Add Window xclass and default_xclass setter and getter. (Changes the XA_WM_CLASS property of the window)
 
 ## [1.2.19] - 2021-12-03
 - Fix docs for dialog::message_title_default(). Thanks @hannesbraun.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 
 ## [1.2.20] - Unreleased
+- Cleanup macros and surrounding api. Thanks @AshfordN.
 - Update doc comment on draw::set_line_style().
 - Add Window xclass and default_xclass setter and getter. (Changes the XA_WM_CLASS property of the window)
 - Add `Color::from_hex_str(&str)` and `to_hex_str()`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 
+## [1.2.20] - Unreleased
+- Update doc comment on draw::set_line_style().
+
 ## [1.2.19] - 2021-12-03
 - Fix docs for dialog::message_title_default(). Thanks @hannesbraun.
 - Add TreeItem::set_label_fgcolor() and label_fgcolor(), deprecate the older names. Thanks @AshfordN.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 ## [1.2.20] - Unreleased
 - Update doc comment on draw::set_line_style().
 - Add Window xclass and default_xclass setter and getter. (Changes the XA_WM_CLASS property of the window)
-- Add `Color::from_html_color(&str)` and `to_html_color()`.
+- Add `Color::from_hex_str(&str)` and `to_hex_str()`.
+- Optimize Color::from_rgba_tuple().
 
 ## [1.2.19] - 2021-12-03
 - Fix docs for dialog::message_title_default(). Thanks @hannesbraun.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Optimize Color::from_rgba_tuple().
 - Add draw::text_extents().
 - Properly `cfltk_` prefix extern Cocoa wrapper functions.
-- Fix build on 32-bit X11 systems (introduced by Window::platform_hide and platform_show).
+- Fix build on 32-bit X11 systems (introduced in 1.2.11 by Window::platform_hide() and platform_show()).
 
 ## [1.2.19] - 2021-12-03
 - Fix docs for dialog::message_title_default(). Thanks @hannesbraun.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,15 @@
 # Changelog
 
 
-## [1.2.20] - Unreleased
+## [1.2.20] - 2021-12-09
 - Cleanup macros and surrounding api. Thanks @AshfordN.
 - Update doc comment on draw::set_line_style().
 - Add Window xclass and default_xclass setter and getter. (Changes the XA_WM_CLASS property of the window)
 - Add `Color::from_hex_str(&str)` and `to_hex_str()`.
 - Optimize Color::from_rgba_tuple().
+- Add draw::text_extents().
+- Properly `cfltk_` prefix extern Cocoa wrapper functions.
+- Fix build on 32-bit X11 systems (introduced by Window::platform_hide and platform_show).
 
 ## [1.2.19] - 2021-12-03
 - Fix docs for dialog::message_title_default(). Thanks @hannesbraun.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ## [1.2.20] - Unreleased
 - Update doc comment on draw::set_line_style().
 - Add Window xclass and default_xclass setter and getter. (Changes the XA_WM_CLASS property of the window)
+- Add `Color::from_html_color(&str)` and `to_html_color()`.
 
 ## [1.2.19] - 2021-12-03
 - Fix docs for dialog::message_title_default(). Thanks @hannesbraun.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-## [1.2.19] - Unreleased
+## [1.2.19] - 2021-12-03
 - Fix docs for dialog::message_title_default(). Thanks @hannesbraun.
 - Add TreeItem::set_label_fgcolor() and label_fgcolor(), deprecate the older names. Thanks @AshfordN.
 - Add TreeItem::as_ptr().

--- a/fltk-sys/Cargo.toml
+++ b/fltk-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk-sys"
-version = "1.2.18"
+version = "1.2.19"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 build = "build/main.rs"
 edition = "2018"

--- a/fltk-sys/Cargo.toml
+++ b/fltk-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk-sys"
-version = "1.2.19"
+version = "1.2.20"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 build = "build/main.rs"
 edition = "2018"

--- a/fltk-sys/src/dialog.rs
+++ b/fltk-sys/src/dialog.rs
@@ -100,6 +100,16 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    pub fn Fl_choice_n(
+        x: ::std::os::raw::c_int,
+        y: ::std::os::raw::c_int,
+        txt: *const ::std::os::raw::c_char,
+        b0: *const ::std::os::raw::c_char,
+        b1: *const ::std::os::raw::c_char,
+        b2: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
     pub fn Fl_input(
         x: ::std::os::raw::c_int,
         y: ::std::os::raw::c_int,
@@ -123,6 +133,14 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_choice2(
+        txt: *const ::std::os::raw::c_char,
+        b0: *const ::std::os::raw::c_char,
+        b1: *const ::std::os::raw::c_char,
+        b2: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn Fl_choice2_n(
         txt: *const ::std::os::raw::c_char,
         b0: *const ::std::os::raw::c_char,
         b1: *const ::std::os::raw::c_char,

--- a/fltk-sys/src/window.rs
+++ b/fltk-sys/src/window.rs
@@ -498,6 +498,18 @@ extern "C" {
 extern "C" {
     pub fn Fl_Window_set_raw_handle(self_: *mut Fl_Window, handle: *mut ::std::os::raw::c_void);
 }
+extern "C" {
+    pub fn Fl_Window_default_xclass() -> *const ::std::os::raw::c_char;
+}
+extern "C" {
+    pub fn Fl_Window_xclass(self_: *const Fl_Window) -> *const ::std::os::raw::c_char;
+}
+extern "C" {
+    pub fn Fl_Window_set_default_xclass(s: *const ::std::os::raw::c_char);
+}
+extern "C" {
+    pub fn Fl_Window_set_xclass(self_: *mut Fl_Window, s: *const ::std::os::raw::c_char);
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct Fl_Single_Window {

--- a/fltk/Cargo.toml
+++ b/fltk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk"
-version = "1.2.19"
+version = "1.2.20"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 edition = "2018"
 description = "Rust bindings for the FLTK GUI library"

--- a/fltk/Cargo.toml
+++ b/fltk/Cargo.toml
@@ -17,7 +17,7 @@ name = "fltk"
 path = "src/lib.rs"
 
 [dependencies]
-fltk-sys = { path = "../fltk-sys", version = "=1.2.19" }
+fltk-sys = { path = "../fltk-sys", version = "=1.2.20" }
 bitflags = "^1.3"
 paste = "1"
 raw-window-handle = { version = "^0.3", optional = true }

--- a/fltk/Cargo.toml
+++ b/fltk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk"
-version = "1.2.18"
+version = "1.2.19"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 edition = "2018"
 description = "Rust bindings for the FLTK GUI library"
@@ -17,7 +17,7 @@ name = "fltk"
 path = "src/lib.rs"
 
 [dependencies]
-fltk-sys = { path = "../fltk-sys", version = "=1.2.18" }
+fltk-sys = { path = "../fltk-sys", version = "=1.2.19" }
 bitflags = "^1.3"
 paste = "1"
 raw-window-handle = { version = "^0.3", optional = true }

--- a/fltk/examples/custom_choice.rs
+++ b/fltk/examples/custom_choice.rs
@@ -48,13 +48,13 @@ impl DerefMut for PopupButton {
 pub struct MyPopup {
     win: window::Window,
     val: Rc<RefCell<String>>,
-    idx: Rc<RefCell<i32>>,
+    idx: RefCell<i32>,
 }
 
 impl MyPopup {
     pub fn new(choices: &[&str]) -> Self {
         let val = Rc::from(RefCell::from(String::from("")));
-        let idx = Rc::from(RefCell::from(0));
+        let idx = RefCell::from(0);
         let mut win = window::Window::default().with_size(120, choices.len() as i32 * 25);
         win.set_color(Color::White);
         let mut pack = group::Pack::default().size_of_parent();

--- a/fltk/examples/custom_choice.rs
+++ b/fltk/examples/custom_choice.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use fltk::{enums::*, prelude::*, *};
 use std::cell::RefCell;
 use std::ops::{Deref, DerefMut};
@@ -61,8 +63,7 @@ impl MyPopup {
         win.set_border(false);
         win.make_modal(true);
         win.end();
-        let mut i = 0;
-        for choice in choices {
+        for (i, choice) in choices.iter().enumerate() {
             let mut but = PopupButton::new(choice);
             but.clear_visible_focus();
             but.set_callback({
@@ -71,12 +72,11 @@ impl MyPopup {
                 let idx = idx.clone();
                 move |b| {
                     *val.borrow_mut() = b.label();
-                    *idx.borrow_mut() = i;
+                    *idx.borrow_mut() = i as i32;
                     win.hide();
                 }
             });
             pack.add(&*but);
-            i += 1;
         }
         pack.auto_layout();
         Self { win, val, idx }
@@ -101,7 +101,7 @@ struct MyChoice {
 
 impl MyChoice {
     pub fn new<S: Into<Option<&'static str>>>(x: i32, y: i32, w: i32, h: i32, label: S) -> Self {
-        let mut grp = group::Group::new(x, y, w, h, label).with_align(Align::Left);
+        let grp = group::Group::new(x, y, w, h, label).with_align(Align::Left);
         let mut frame = frame::Frame::new(x, y, w - w / 4, h, None);
         frame.set_frame(FrameType::DownBox);
         frame.set_color(Color::BackGround2);

--- a/fltk/examples/custom_choice.rs
+++ b/fltk/examples/custom_choice.rs
@@ -84,7 +84,7 @@ impl MyPopup {
     pub fn popup(&mut self, x: i32, y: i32) -> (String, i32) {
         self.win.show();
         self.win
-            .set_pos(app::event_x_root() - x, app::event_y_root() + y);
+            .set_pos(app::event_x_root() - x, app::event_y_root() + y + 10);
         while self.win.shown() {
             app::wait();
         }
@@ -114,7 +114,7 @@ impl MyChoice {
             let mut f = frame.clone();
             move |b| {
                 let mut menu = MyPopup::new(&*c.borrow());
-                let s = menu.popup(b.w() * 4, b.h() - 10);
+                let s = menu.popup(b.w() * 4, 0);
                 f.set_label(&s.0);
             }
         });

--- a/fltk/examples/custom_choice.rs
+++ b/fltk/examples/custom_choice.rs
@@ -57,9 +57,8 @@ impl MyPopup {
         let idx = RefCell::from(0);
         let mut win = window::Window::default().with_size(120, choices.len() as i32 * 25);
         win.set_color(Color::White);
-        let mut pack = group::Pack::default().size_of_parent();
-        pack.set_frame(FrameType::ThinUpFrame);
-        pack.set_color(Color::White);
+        win.set_frame(FrameType::BorderBox);
+        let mut pack = group::Pack::new(1, 1, win.w() - 2, win.h() -2, None);
         win.set_border(false);
         win.make_modal(true);
         win.end();

--- a/fltk/examples/custom_choice.rs
+++ b/fltk/examples/custom_choice.rs
@@ -1,0 +1,161 @@
+use fltk::{enums::*, prelude::*, *};
+use std::cell::RefCell;
+use std::ops::{Deref, DerefMut};
+use std::rc::Rc;
+
+pub struct PopupButton {
+    but: button::Button,
+}
+
+impl PopupButton {
+    pub fn new(label: &str) -> Self {
+        let mut but = button::Button::default().with_label(label);
+        but.set_frame(FrameType::FlatBox);
+        but.set_color(Color::White);
+        but.handle(|b, ev| match ev {
+            Event::Enter => {
+                b.set_color(Color::Blue);
+                b.top_window().unwrap().redraw();
+                true
+            }
+            Event::Leave => {
+                b.set_color(Color::White);
+                b.top_window().unwrap().redraw();
+                true
+            }
+            _ => false,
+        });
+        Self { but }
+    }
+}
+
+impl Deref for PopupButton {
+    type Target = button::Button;
+
+    fn deref(&self) -> &Self::Target {
+        &self.but
+    }
+}
+
+impl DerefMut for PopupButton {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.but
+    }
+}
+
+pub struct MyPopup {
+    win: window::Window,
+    val: Rc<RefCell<String>>,
+    idx: Rc<RefCell<i32>>,
+}
+
+impl MyPopup {
+    pub fn new(choices: &[&str]) -> Self {
+        let val = Rc::from(RefCell::from(String::from("")));
+        let idx = Rc::from(RefCell::from(0));
+        let mut win = window::Window::default().with_size(120, choices.len() as i32 * 25);
+        win.set_color(Color::White);
+        let mut pack = group::Pack::default().size_of_parent();
+        pack.set_frame(FrameType::ThinUpFrame);
+        pack.set_color(Color::White);
+        win.set_border(false);
+        win.make_modal(true);
+        win.end();
+        let mut i = 0;
+        for choice in choices {
+            let mut but = PopupButton::new(choice);
+            but.clear_visible_focus();
+            but.set_callback({
+                let mut win = win.clone();
+                let val = val.clone();
+                let idx = idx.clone();
+                move |b| {
+                    *val.borrow_mut() = b.label();
+                    *idx.borrow_mut() = i;
+                    win.hide();
+                }
+            });
+            pack.add(&*but);
+            i += 1;
+        }
+        pack.auto_layout();
+        Self { win, val, idx }
+    }
+    pub fn popup(&mut self, x: i32, y: i32) -> (String, i32) {
+        self.win.show();
+        self.win
+            .set_pos(app::event_x_root() - x, app::event_y_root() + y);
+        while self.win.shown() {
+            app::wait();
+        }
+        (self.val.borrow().to_string(), *self.idx.borrow())
+    }
+}
+
+struct MyChoice {
+    grp: group::Group,
+    frame: frame::Frame,
+    btn: button::Button,
+    choices: Rc<RefCell<Vec<&'static str>>>,
+}
+
+impl MyChoice {
+    pub fn new<S: Into<Option<&'static str>>>(x: i32, y: i32, w: i32, h: i32, label: S) -> Self {
+        let mut grp = group::Group::new(x, y, w, h, label).with_align(Align::Left);
+        let mut frame = frame::Frame::new(x, y, w - w / 4, h, None);
+        frame.set_frame(FrameType::DownBox);
+        frame.set_color(Color::BackGround2);
+        let mut btn = button::Button::new(x + w - w / 4, y, w / 4, h, "@2>");
+        btn.clear_visible_focus();
+        grp.end();
+        let choices = Rc::from(RefCell::from(vec![]));
+        btn.set_callback({
+            let c = choices.clone();
+            let mut f = frame.clone();
+            move |b| {
+                let mut menu = MyPopup::new(&*c.borrow());
+                let s = menu.popup(b.w() * 4, b.h() - 10);
+                f.set_label(&s.0);
+            }
+        });
+        Self {
+            grp,
+            frame,
+            btn,
+            choices,
+        }
+    }
+
+    pub fn add_choices(&mut self, choices: &[&'static str]) {
+        *self.choices.borrow_mut() = choices.to_vec();
+    }
+
+    pub fn button(&mut self) -> &mut button::Button {
+        &mut self.btn
+    }
+
+    pub fn frame(&mut self) -> &mut frame::Frame {
+        &mut self.frame
+    }
+
+    pub fn group(&mut self) -> &mut group::Group {
+        &mut self.grp
+    }
+
+    pub fn set_current_choice(&mut self, idx: i32) {
+        self.frame.set_label(self.choices.borrow()[idx as usize])
+    }
+}
+
+fn main() {
+    let app = app::App::default();
+    let mut win = window::Window::default().with_size(400, 300);
+    let mut choice = MyChoice::new(160, 200, 100, 30, None);
+    choice.add_choices(&["choice1", "choice2", "choice3"]);
+    choice.set_current_choice(1);
+    choice.button().set_frame(FrameType::BorderBox);
+    choice.frame().set_frame(FrameType::BorderBox);
+    win.end();
+    win.show();
+    app.run().unwrap();
+}

--- a/fltk/examples/paint.rs
+++ b/fltk/examples/paint.rs
@@ -74,6 +74,7 @@ fn main() {
                 draw_point(x, y);
                 offs.end();
                 f.redraw();
+                set_line_style(LineStyle::Solid, 0);
                 true
             }
             Event::Drag => {
@@ -86,6 +87,7 @@ fn main() {
                 y = coords.1;
                 offs.end();
                 f.redraw();
+                set_line_style(LineStyle::Solid, 0);
                 true
             }
             _ => false,

--- a/fltk/src/browser.rs
+++ b/fltk/src/browser.rs
@@ -1,8 +1,6 @@
-use crate::enums::{Align, CallbackTrigger, Color, Damage, Event, Font, FrameType, LabelType};
-use crate::image::Image;
+use crate::enums::{Color, Font};
 use crate::prelude::*;
 use crate::utils::FlString;
-use crate::window::Window;
 use fltk_sys::browser::*;
 use std::{
     ffi::{CStr, CString},

--- a/fltk/src/button.rs
+++ b/fltk/src/button.rs
@@ -1,16 +1,7 @@
-use crate::enums::{
-    Align, CallbackTrigger, Color, Damage, Event, Font, FrameType, LabelType, Shortcut,
-};
-use crate::image::Image;
 use crate::prelude::*;
 use crate::utils::FlString;
-use crate::window::Window;
 use fltk_sys::button::*;
-use std::{
-    ffi::{CStr, CString},
-    mem,
-    os::raw,
-};
+use std::ffi::{CStr, CString};
 
 /// Creates a normal button
 #[derive(Debug)]

--- a/fltk/src/dialog.rs
+++ b/fltk/src/dialog.rs
@@ -262,6 +262,24 @@ pub fn choice(x: i32, y: i32, txt: &str, b0: &str, b1: &str, b2: &str) -> i32 {
     }
 }
 
+#[doc(Hidden)]
+/// Displays a choice box with upto three choices.
+/// An empty choice will not be shown
+pub fn choice2(x: i32, y: i32, txt: &str, b0: &str, b1: &str, b2: &str) -> Option<i32> {
+    unsafe {
+        let txt = CString::safe_new(txt);
+        let b0 = CString::safe_new(b0);
+        let b1 = CString::safe_new(b1);
+        let b2 = CString::safe_new(b2);
+        let ret = Fl_choice_n(x, y, txt.as_ptr(), b0.as_ptr(), b1.as_ptr(), b2.as_ptr()) as i32;
+        if ret < 0 {
+            None
+        } else {
+            Some(ret)
+        }
+    }
+}
+
 /// Displays an input box, which returns the inputted string.
 /// Can be used for gui io
 pub fn input(x: i32, y: i32, txt: &str, deflt: &str) -> Option<String> {
@@ -324,6 +342,24 @@ pub fn choice_default(txt: &str, b0: &str, b1: &str, b2: &str) -> i32 {
         let b1 = CString::safe_new(b1);
         let b2 = CString::safe_new(b2);
         Fl_choice2(txt.as_ptr(), b0.as_ptr(), b1.as_ptr(), b2.as_ptr()) as i32
+    }
+}
+
+#[doc(Hidden)]
+/// Displays a choice box with upto three choices.
+/// An empty choice will not be shown
+pub fn choice2_default(txt: &str, b0: &str, b1: &str, b2: &str) -> Option<i32> {
+    unsafe {
+        let txt = CString::safe_new(txt);
+        let b0 = CString::safe_new(b0);
+        let b1 = CString::safe_new(b1);
+        let b2 = CString::safe_new(b2);
+        let ret = Fl_choice2_n(txt.as_ptr(), b0.as_ptr(), b1.as_ptr(), b2.as_ptr()) as i32;
+        if ret < 0 {
+            None
+        } else {
+            Some(ret)
+        }
     }
 }
 

--- a/fltk/src/dialog.rs
+++ b/fltk/src/dialog.rs
@@ -262,9 +262,8 @@ pub fn choice(x: i32, y: i32, txt: &str, b0: &str, b1: &str, b2: &str) -> i32 {
     }
 }
 
-#[doc(hidden)]
 /// Displays a choice box with upto three choices.
-/// An empty choice will not be shown
+/// An empty choice will not be shown. Closing the dialog returns None
 pub fn choice2(x: i32, y: i32, txt: &str, b0: &str, b1: &str, b2: &str) -> Option<i32> {
     unsafe {
         let txt = CString::safe_new(txt);
@@ -345,9 +344,8 @@ pub fn choice_default(txt: &str, b0: &str, b1: &str, b2: &str) -> i32 {
     }
 }
 
-#[doc(hidden)]
 /// Displays a choice box with upto three choices.
-/// An empty choice will not be shown
+/// An empty choice will not be shown. Closing the dialog returns None
 pub fn choice2_default(txt: &str, b0: &str, b1: &str, b2: &str) -> Option<i32> {
     unsafe {
         let txt = CString::safe_new(txt);

--- a/fltk/src/dialog.rs
+++ b/fltk/src/dialog.rs
@@ -262,7 +262,7 @@ pub fn choice(x: i32, y: i32, txt: &str, b0: &str, b1: &str, b2: &str) -> i32 {
     }
 }
 
-#[doc(Hidden)]
+#[doc(hidden)]
 /// Displays a choice box with upto three choices.
 /// An empty choice will not be shown
 pub fn choice2(x: i32, y: i32, txt: &str, b0: &str, b1: &str, b2: &str) -> Option<i32> {
@@ -345,7 +345,7 @@ pub fn choice_default(txt: &str, b0: &str, b1: &str, b2: &str) -> i32 {
     }
 }
 
-#[doc(Hidden)]
+#[doc(hidden)]
 /// Displays a choice box with upto three choices.
 /// An empty choice will not be shown
 pub fn choice2_default(txt: &str, b0: &str, b1: &str, b2: &str) -> Option<i32> {
@@ -1081,7 +1081,7 @@ impl FileChooser {
         unsafe { Fl_File_Chooser_set_show_label(msg.into_raw()) }
     }
 
-    /// Set "Hidden" label
+    /// Set "hidden" label
     pub fn set_hidden_label(msg: &'static str) {
         let msg = CString::safe_new(msg);
         unsafe { Fl_File_Chooser_set_hidden_label(msg.into_raw()) }

--- a/fltk/src/draw.rs
+++ b/fltk/src/draw.rs
@@ -568,6 +568,19 @@ pub fn measure(txt: &str, draw_symbols: bool) -> (i32, i32) {
     (x, y)
 }
 
+/// Measure the coordinates and size of the text where a bounding box using the returned data would fit the text
+pub fn text_extents(txt: &str) -> (i32, i32, i32, i32) {
+    let txt = CString::safe_new(txt);
+    let mut x = 0;
+    let mut y = 0;
+    let mut w = 0;
+    let mut h = 0;
+    unsafe {
+        Fl_text_extents(txt.as_ptr(), &mut x, &mut y, &mut w, &mut h);
+    }
+    (x, y, w, h)
+}
+
 /// Returns the typographical width of a single character
 pub fn char_width(c: char) -> f64 {
     unsafe { Fl_width3(c as u32) }

--- a/fltk/src/draw.rs
+++ b/fltk/src/draw.rs
@@ -257,6 +257,8 @@ pub fn draw_pie(x: i32, y: i32, width: i32, height: i32, a: f64, b: f64) {
 }
 
 /// Sets the line style
+/// # Warning
+/// You are required to change this back to `set_line_style(LineStyle::Solid, 0)` after finishing
 pub fn set_line_style(style: LineStyle, width: i32) {
     unsafe {
         crate::app::open_display();

--- a/fltk/src/enums.rs
+++ b/fltk/src/enums.rs
@@ -502,6 +502,20 @@ impl Color {
         Color::from_rgb(r, g, b)
     }
 
+    /// Return a Color from an html color format
+    /// # Panics
+    /// The accepted format is `#xxxxxx`
+    pub fn from_html_color(col: &str) -> Color {
+        let col = u32::from_str_radix(&col[1..7], 16).unwrap();
+        Color::from_hex(col)
+    }
+
+    /// Returns an html color format
+    pub fn to_html_color(&self) -> String {
+        let (r, g, b) = self.to_rgb();
+        format!("#{:x}{:x}{:x}", r, g, b)
+    }
+
     /// Returns a color by index of RGBI
     pub fn by_index(idx: u8) -> Color {
         unsafe { mem::transmute(idx as u32) }

--- a/fltk/src/enums.rs
+++ b/fltk/src/enums.rs
@@ -510,7 +510,7 @@ impl Color {
         Color::from_hex(col)
     }
 
-    /// Returns an html color format
+    /// Returns the color in html format
     pub fn to_html_color(&self) -> String {
         let (r, g, b) = self.to_rgb();
         format!("#{:x}{:x}{:x}", r, g, b)

--- a/fltk/src/enums.rs
+++ b/fltk/src/enums.rs
@@ -503,11 +503,12 @@ impl Color {
     }
 
     /// Return a Color from an html color format
-    /// # Panics
-    /// The accepted format is `#xxxxxx`
-    pub fn from_html_color(col: &str) -> Color {
-        let col = u32::from_str_radix(&col[1..7], 16).unwrap();
-        Color::from_hex(col)
+    pub fn from_html_color(col: &str) -> Result<Color, FltkError> {
+        if !col.starts_with('#') || col.len() != 7 {
+            Err(FltkError::Internal(FltkErrorKind::InvalidColor))
+        } else {
+            Ok(Color::from_hex(u32::from_str_radix(&col[1..7], 16)?))
+        }
     }
 
     /// Returns the color in html format

--- a/fltk/src/enums.rs
+++ b/fltk/src/enums.rs
@@ -473,21 +473,25 @@ impl Color {
 
     /// Create color from RGBA using alpha compositing
     pub fn from_rgba_tuple(tup: (u8, u8, u8, u8)) -> Color {
-        let bg_col = if let Some(grp) = crate::group::Group::try_current() {
-            use crate::prelude::WidgetExt;
-            grp.color()
+        if tup.3 != 255 {
+            let bg_col = if let Some(grp) = crate::group::Group::try_current() {
+                use crate::prelude::WidgetExt;
+                grp.color()
+            } else {
+                Color::BackGround
+            };
+            let bg_col = bg_col.to_rgb();
+            let alpha = tup.3 as f32 / 255.0;
+            let r = alpha * tup.0 as f32 + (1.0 - alpha) * bg_col.0 as f32;
+            let r = r as u8;
+            let g = alpha * tup.1 as f32 + (1.0 - alpha) * bg_col.1 as f32;
+            let g = g as u8;
+            let b = alpha * tup.2 as f32 + (1.0 - alpha) * bg_col.2 as f32;
+            let b = b as u8;
+            Color::from_rgb(r, g, b)
         } else {
-            Color::BackGround
-        };
-        let bg_col = bg_col.to_rgb();
-        let alpha = tup.3 as f32 / 255.0;
-        let r = alpha * tup.0 as f32 + (1.0 - alpha) * bg_col.0 as f32;
-        let r = r as u8;
-        let g = alpha * tup.1 as f32 + (1.0 - alpha) * bg_col.1 as f32;
-        let g = g as u8;
-        let b = alpha * tup.2 as f32 + (1.0 - alpha) * bg_col.2 as f32;
-        let b = b as u8;
-        Color::from_rgb(r, g, b)
+            Color::from_rgb(tup.0, tup.1, tup.2)
+        }
     }
 
     /// Returns a color from hex or decimal
@@ -502,8 +506,8 @@ impl Color {
         Color::from_rgb(r, g, b)
     }
 
-    /// Return a Color from an html color format (`#xxxxxx`)
-    pub fn from_html_color(col: &str) -> Result<Color, FltkError> {
+    /// Return a Color from a hex color format (`#xxxxxx`)
+    pub fn from_hex_str(col: &str) -> Result<Color, FltkError> {
         if !col.starts_with('#') || col.len() != 7 {
             Err(FltkError::Internal(FltkErrorKind::InvalidColor))
         } else {
@@ -511,8 +515,8 @@ impl Color {
         }
     }
 
-    /// Returns the color in html format
-    pub fn to_html_color(&self) -> String {
+    /// Returns the color in hex string format
+    pub fn to_hex_str(&self) -> String {
         let (r, g, b) = self.to_rgb();
         format!("#{:x}{:x}{:x}", r, g, b)
     }

--- a/fltk/src/enums.rs
+++ b/fltk/src/enums.rs
@@ -502,7 +502,7 @@ impl Color {
         Color::from_rgb(r, g, b)
     }
 
-    /// Return a Color from an html color format
+    /// Return a Color from an html color format (`#xxxxxx`)
     pub fn from_html_color(col: &str) -> Result<Color, FltkError> {
         if !col.starts_with('#') || col.len() != 7 {
             Err(FltkError::Internal(FltkErrorKind::InvalidColor))

--- a/fltk/src/enums.rs
+++ b/fltk/src/enums.rs
@@ -518,7 +518,7 @@ impl Color {
     /// Returns the color in hex string format
     pub fn to_hex_str(&self) -> String {
         let (r, g, b) = self.to_rgb();
-        format!("#{:x}{:x}{:x}", r, g, b)
+        format!("#{:02x}{:02x}{:02x}", r, g, b)
     }
 
     /// Returns a color by index of RGBI

--- a/fltk/src/frame.rs
+++ b/fltk/src/frame.rs
@@ -1,14 +1,7 @@
-use crate::enums::{Align, CallbackTrigger, Color, Damage, Event, Font, FrameType, LabelType};
-use crate::image::Image;
 use crate::prelude::*;
 use crate::utils::FlString;
-use crate::window::Window;
 use fltk_sys::frame::*;
-use std::{
-    ffi::{CStr, CString},
-    mem,
-    os::raw,
-};
+use std::ffi::{CStr, CString};
 
 /// Creates a new frame, an equivalent of `Fl_Box`
 #[derive(Debug)]

--- a/fltk/src/group.rs
+++ b/fltk/src/group.rs
@@ -1,14 +1,11 @@
-use crate::enums::{Align, CallbackTrigger, Color, Damage, Event, Font, FrameType, LabelType};
-use crate::image::Image;
+use crate::enums::Align;
 use crate::prelude::*;
 use crate::utils::FlString;
-use crate::window::Window;
 use crate::widget::Widget;
 use fltk_sys::group::*;
 use std::{
     ffi::{CStr, CString},
     mem,
-    os::raw,
 };
 
 /// Creates a group widget
@@ -24,7 +21,7 @@ crate::macros::widget::impl_widget_base!(Group, Fl_Group);
 crate::macros::group::impl_group_ext!(Group, Fl_Group);
 
 impl Group {
-    #[deprecated(since="1.2.18", note="please use `try_current` instead")]
+    #[deprecated(since = "1.2.18", note = "please use `try_current` instead")]
     /// Get the current group
     pub fn current() -> Group {
         unsafe {
@@ -337,7 +334,7 @@ impl Wizard {
         unsafe { Fl_Wizard_prev(self.inner) }
     }
 
-    #[deprecated(since="1.2.18", note="please use `try_current_widget` instead")]
+    #[deprecated(since = "1.2.18", note = "please use `try_current_widget` instead")]
     /// Gets the underlying widget of the current view
     pub fn current_widget(&mut self) -> Widget {
         unsafe {

--- a/fltk/src/image.rs
+++ b/fltk/src/image.rs
@@ -2,11 +2,7 @@ use crate::enums::ColorDepth;
 use crate::prelude::*;
 use crate::utils::FlString;
 use fltk_sys::image::*;
-use std::{
-    ffi::CString,
-    mem,
-    sync::atomic::{AtomicUsize, Ordering},
-};
+use std::{ffi::CString, mem, sync::atomic::AtomicUsize};
 
 /// Wrapper around `Fl_Image`, used to wrap other image types
 #[derive(Debug)]

--- a/fltk/src/input.rs
+++ b/fltk/src/input.rs
@@ -1,13 +1,10 @@
-use crate::enums::{Align, CallbackTrigger, Color, Damage, Event, Font, FrameType, LabelType};
-use crate::image::Image;
+use crate::enums::FrameType;
 use crate::prelude::*;
 use crate::utils::FlString;
-use crate::window::Window;
 use fltk_sys::input::*;
 use std::{
     ffi::{CStr, CString},
     mem,
-    os::raw,
 };
 
 /// Creates an input widget

--- a/fltk/src/lib.rs
+++ b/fltk/src/lib.rs
@@ -296,7 +296,6 @@ pub mod image;
 /// Input widgets
 pub mod input;
 
-#[doc(hidden)]
 /// mod macros;
 pub mod macros;
 

--- a/fltk/src/macros/browser.rs
+++ b/fltk/src/macros/browser.rs
@@ -147,7 +147,7 @@ macro_rules! impl_browser_ext {
                             None
                         } else {
                             let img =
-                                Image::from_image_ptr(image_ptr as *mut fltk_sys::image::Fl_Image);
+                            $crate::image::Image::from_image_ptr(image_ptr as *mut fltk_sys::image::Fl_Image);
                             Some(Box::new(img))
                         }
                     }
@@ -220,7 +220,7 @@ macro_rules! impl_browser_ext {
                     unsafe {
                         let mut v = arr.to_vec();
                         v.push(0);
-                        let v = mem::ManuallyDrop::new(v);
+                        let v = std::mem::ManuallyDrop::new(v);
                         [<$flname _set_column_widths>](self.inner, v.as_ptr());
                     }
                 }
@@ -255,12 +255,12 @@ macro_rules! impl_browser_ext {
                     unsafe { [<$flname _set_hposition>](self.inner, pos as i32) }
                 }
 
-                fn has_scrollbar(&self) -> BrowserScrollbar {
+                fn has_scrollbar(&self) -> $crate::browser::BrowserScrollbar {
                     assert!(!self.was_deleted());
-                    unsafe { mem::transmute([<$flname _has_scrollbar>](self.inner)) }
+                    unsafe { std::mem::transmute([<$flname _has_scrollbar>](self.inner)) }
                 }
 
-                fn set_has_scrollbar(&mut self, mode: BrowserScrollbar) {
+                fn set_has_scrollbar(&mut self, mode: $crate::browser::BrowserScrollbar) {
                     assert!(!self.was_deleted());
                     unsafe {
                         [<$flname _set_has_scrollbar>](self.inner, mode as raw::c_uchar)
@@ -282,23 +282,23 @@ macro_rules! impl_browser_ext {
                     unsafe { [<$flname _sort>](self.inner) }
                 }
 
-                fn scrollbar(&self) -> crate::valuator::Scrollbar {
+                fn scrollbar(&self) -> $crate::valuator::Scrollbar {
                     assert!(!self.was_deleted());
                     unsafe {
                         let ptr = [<$flname _scrollbar>](self.inner);
                         assert!(!ptr.is_null());
-                        crate::valuator::Scrollbar::from_widget_ptr(
+                        $crate::valuator::Scrollbar::from_widget_ptr(
                             ptr as *mut fltk_sys::widget::Fl_Widget,
                         )
                     }
                 }
 
-                fn hscrollbar(&self) -> crate::valuator::Scrollbar {
+                fn hscrollbar(&self) -> $crate::valuator::Scrollbar {
                     assert!(!self.was_deleted());
                     unsafe {
                         let ptr = [<$flname _hscrollbar>](self.inner);
                         assert!(!ptr.is_null());
-                        crate::valuator::Scrollbar::from_widget_ptr(
+                        $crate::valuator::Scrollbar::from_widget_ptr(
                             ptr as *mut fltk_sys::widget::Fl_Widget,
                         )
                     }

--- a/fltk/src/macros/browser.rs
+++ b/fltk/src/macros/browser.rs
@@ -1,3 +1,4 @@
+#[doc(hidden)]
 #[macro_export]
 /// Implements BrowserExt
 macro_rules! impl_browser_ext {

--- a/fltk/src/macros/button.rs
+++ b/fltk/src/macros/button.rs
@@ -1,3 +1,4 @@
+#[doc(hidden)]
 #[macro_export]
 /// Implements ButtonExt
 macro_rules! impl_button_ext {

--- a/fltk/src/macros/button.rs
+++ b/fltk/src/macros/button.rs
@@ -4,14 +4,14 @@ macro_rules! impl_button_ext {
     ($name: ident, $flname: ident) => {
         paste::paste! {
             unsafe impl ButtonExt for $name {
-                fn shortcut(&self) -> Shortcut {
+                fn shortcut(&self) -> $crate::enums::Shortcut {
                     unsafe {
                         assert!(!self.was_deleted());
-                        mem::transmute([<$flname _shortcut>](self.inner))
+                        std::mem::transmute([<$flname _shortcut>](self.inner))
                     }
                 }
 
-                fn set_shortcut(&mut self, shortcut: Shortcut) {
+                fn set_shortcut(&mut self, shortcut: $crate::enums::Shortcut) {
                     unsafe {
                         assert!(!self.was_deleted());
                         [<$flname _set_shortcut>](self.inner, shortcut.bits() as i32)
@@ -53,14 +53,14 @@ macro_rules! impl_button_ext {
                     }
                 }
 
-                fn set_down_frame(&mut self, f: FrameType) {
+                fn set_down_frame(&mut self, f: $crate::enums::FrameType) {
                     assert!(!self.was_deleted());
                     unsafe { [<$flname _set_down_box>](self.inner, f as i32) }
                 }
 
-                fn down_frame(&self) -> FrameType {
+                fn down_frame(&self) -> $crate::enums::FrameType {
                     assert!(!self.was_deleted());
-                    unsafe { mem::transmute([<$flname _down_box>](self.inner)) }
+                    unsafe { std::mem::transmute([<$flname _down_box>](self.inner)) }
                 }
             }
         }

--- a/fltk/src/macros/display.rs
+++ b/fltk/src/macros/display.rs
@@ -1,3 +1,4 @@
+#[doc(hidden)]
 #[macro_export]
 /// Implements DisplayExt
 macro_rules! impl_display_ext {

--- a/fltk/src/macros/display.rs
+++ b/fltk/src/macros/display.rs
@@ -4,20 +4,20 @@ macro_rules! impl_display_ext {
     ($name: ident, $flname: ident) => {
         paste::paste! {
             unsafe impl DisplayExt for $name {
-                fn buffer(&self) -> Option<TextBuffer> {
+                fn buffer(&self) -> Option<$crate::text::TextBuffer> {
                     unsafe {
                         assert!(!self.was_deleted());
                         let buffer = [<$flname _get_buffer>](self.inner);
                         if buffer.is_null() {
                             None
                         } else {
-                            let buf = TextBuffer::from_ptr(buffer);
+                            let buf = $crate::text::TextBuffer::from_ptr(buffer);
                             Some(buf)
                         }
                     }
                 }
 
-                fn set_buffer<B: Into<Option<crate::text::TextBuffer>>>(&mut self, buffer: B) {
+                fn set_buffer<B: Into<Option<$crate::text::TextBuffer>>>(&mut self, buffer: B) {
                     unsafe {
                         assert!(!self.was_deleted());
                         if let Some(buffer) = buffer.into() {
@@ -32,38 +32,38 @@ macro_rules! impl_display_ext {
                     }
                 }
 
-                fn style_buffer(&self) -> Option<TextBuffer> {
+                fn style_buffer(&self) -> Option<$crate::text::TextBuffer> {
                     unsafe {
                         assert!(!self.was_deleted());
                         let buffer = [<$flname _get_style_buffer>](self.inner);
                         if buffer.is_null() {
                             None
                         } else {
-                            let buf = TextBuffer::from_ptr(buffer);
+                            let buf = $crate::text::TextBuffer::from_ptr(buffer);
                             Some(buf)
                         }
                     }
                 }
 
-                fn text_font(&self) -> Font {
+                fn text_font(&self) -> $crate::enums::Font {
                     assert!(!self.was_deleted());
                     assert!(self.buffer().is_some());
-                    unsafe { mem::transmute([<$flname _text_font>](self.inner)) }
+                    unsafe { std::mem::transmute([<$flname _text_font>](self.inner)) }
                 }
 
-                fn set_text_font(&mut self, font: Font) {
+                fn set_text_font(&mut self, font: $crate::enums::Font) {
                     assert!(!self.was_deleted());
                     assert!(self.buffer().is_some());
                     unsafe { [<$flname _set_text_font>](self.inner, font.bits() as i32) }
                 }
 
-                fn text_color(&self) -> Color {
+                fn text_color(&self) -> $crate::enums::Color {
                     assert!(!self.was_deleted());
                     assert!(self.buffer().is_some());
-                    unsafe { mem::transmute([<$flname _text_color>](self.inner)) }
+                    unsafe { std::mem::transmute([<$flname _text_color>](self.inner)) }
                 }
 
-                fn set_text_color(&mut self, color: Color) {
+                fn set_text_color(&mut self, color: $crate::enums::Color) {
                     assert!(!self.was_deleted());
                     assert!(self.buffer().is_some());
                     unsafe { [<$flname _set_text_color>](self.inner, color.bits() as u32) }
@@ -203,18 +203,18 @@ macro_rules! impl_display_ext {
                     }
                 }
 
-                fn set_highlight_data<B: Into<Option<TextBuffer>>>(
+                fn set_highlight_data<B: Into<Option<$crate::text::TextBuffer>>>(
                     &mut self,
                     style_buffer: B,
-                    entries: Vec<StyleTableEntry>,
+                    entries: Vec<$crate::text::StyleTableEntry>,
                 ) {
                     assert!(!self.was_deleted());
                     assert!(entries.len() < 61);
                     let entries = if entries.len() == 0 {
-                        vec![StyleTableEntry {
-                            color: Color::Black,
-                            font: Font::Helvetica,
-                            size: crate::app::font_size(),
+                        vec![$crate::text::StyleTableEntry {
+                            color: $crate::enums::Color::Black,
+                            font: $crate::enums::Font::Helvetica,
+                            size: $crate::app::font_size(),
                         }]
                     } else {
                         entries
@@ -256,11 +256,11 @@ macro_rules! impl_display_ext {
                     }
                 }
 
-                fn unset_highlight_data(&mut self, style_buffer: TextBuffer) {
+                fn unset_highlight_data(&mut self, style_buffer: $crate::text::TextBuffer) {
                     assert!(!self.was_deleted());
                     unsafe {
-                        let mut colors = [Color::Black.bits()];
-                        let mut fonts = [Font::Helvetica.bits()];
+                        let mut colors = [$crate::enums::Color::Black.bits()];
+                        let mut fonts = [$crate::enums::Font::Helvetica.bits()];
                         let mut sizes = [14];
                         [<$flname _set_highlight_data>](
                             self.inner,
@@ -273,14 +273,14 @@ macro_rules! impl_display_ext {
                     }
                 }
 
-                fn set_cursor_style(&mut self, style: crate::text::Cursor) {
+                fn set_cursor_style(&mut self, style: $crate::text::Cursor) {
                     unsafe {
                         assert!(!self.was_deleted());
                         [<$flname _set_cursor_style>](self.inner, style as i32)
                     }
                 }
 
-                fn set_cursor_color(&mut self, color: Color) {
+                fn set_cursor_color(&mut self, color: $crate::enums::Color) {
                     unsafe {
                         assert!(!self.was_deleted());
                         [<$flname _set_cursor_color>](self.inner, color.bits() as u32)
@@ -294,24 +294,24 @@ macro_rules! impl_display_ext {
                     }
                 }
 
-                fn set_scrollbar_align(&mut self, align: Align) {
+                fn set_scrollbar_align(&mut self, align: $crate::enums::Align) {
                     unsafe {
                         assert!(!self.was_deleted());
                         [<$flname _set_scrollbar_align>](self.inner, align.bits() as i32)
                     }
                 }
 
-                fn cursor_style(&self) -> crate::text::Cursor {
+                fn cursor_style(&self) -> $crate::text::Cursor {
                     unsafe {
                         assert!(!self.was_deleted());
-                        mem::transmute([<$flname _cursor_style>](self.inner))
+                        std::mem::transmute([<$flname _cursor_style>](self.inner))
                     }
                 }
 
-                fn cursor_color(&self) -> Color {
+                fn cursor_color(&self) -> $crate::enums::Color {
                     unsafe {
                         assert!(!self.was_deleted());
-                        mem::transmute([<$flname _cursor_color>](self.inner))
+                        std::mem::transmute([<$flname _cursor_color>](self.inner))
                     }
                 }
 
@@ -322,10 +322,10 @@ macro_rules! impl_display_ext {
                     }
                 }
 
-                fn scrollbar_align(&self) -> Align {
+                fn scrollbar_align(&self) -> $crate::enums::Align {
                     unsafe {
                         assert!(!self.was_deleted());
-                        mem::transmute([<$flname _scrollbar_align>](self.inner))
+                        std::mem::transmute([<$flname _scrollbar_align>](self.inner))
                     }
                 }
 
@@ -436,17 +436,17 @@ macro_rules! impl_display_ext {
                     }
                 }
 
-                fn set_linenumber_font(&mut self, font: Font) {
+                fn set_linenumber_font(&mut self, font: $crate::enums::Font) {
                     unsafe {
                         assert!(!self.was_deleted());
                         [<$flname _set_linenumber_font>](self.inner, font.bits() as i32)
                     }
                 }
 
-                fn linenumber_font(&self) -> Font {
+                fn linenumber_font(&self) -> $crate::enums::Font {
                     unsafe {
                         assert!(!self.was_deleted());
-                        mem::transmute([<$flname _linenumber_font>](self.inner))
+                        std::mem::transmute([<$flname _linenumber_font>](self.inner))
                     }
                 }
 
@@ -464,7 +464,7 @@ macro_rules! impl_display_ext {
                     }
                 }
 
-                fn set_linenumber_fgcolor(&mut self, color: Color) {
+                fn set_linenumber_fgcolor(&mut self, color: $crate::enums::Color) {
                     unsafe {
                         assert!(!self.was_deleted());
                         [<$flname _set_linenumber_fgcolor>](
@@ -474,14 +474,14 @@ macro_rules! impl_display_ext {
                     }
                 }
 
-                fn linenumber_fgcolor(&self) -> Color {
+                fn linenumber_fgcolor(&self) -> $crate::enums::Color {
                     unsafe {
                         assert!(!self.was_deleted());
-                        mem::transmute([<$flname _linenumber_fgcolor>](self.inner))
+                        std::mem::transmute([<$flname _linenumber_fgcolor>](self.inner))
                     }
                 }
 
-                fn set_linenumber_bgcolor(&mut self, color: Color) {
+                fn set_linenumber_bgcolor(&mut self, color: $crate::enums::Color) {
                     unsafe {
                         assert!(!self.was_deleted());
                         [<$flname _set_linenumber_bgcolor>](
@@ -491,24 +491,24 @@ macro_rules! impl_display_ext {
                     }
                 }
 
-                fn linenumber_bgcolor(&self) -> Color {
+                fn linenumber_bgcolor(&self) -> $crate::enums::Color {
                     unsafe {
                         assert!(!self.was_deleted());
-                        mem::transmute([<$flname _linenumber_bgcolor>](self.inner))
+                        std::mem::transmute([<$flname _linenumber_bgcolor>](self.inner))
                     }
                 }
 
-                fn set_linenumber_align(&mut self, align: Align) {
+                fn set_linenumber_align(&mut self, align: $crate::enums::Align) {
                     unsafe {
                         assert!(!self.was_deleted());
                         [<$flname _set_linenumber_align>](self.inner, align.bits() as i32)
                     }
                 }
 
-                fn linenumber_align(&self) -> Align {
+                fn linenumber_align(&self) -> $crate::enums::Align {
                     unsafe {
                         assert!(!self.was_deleted());
-                        mem::transmute([<$flname _linenumber_align>](self.inner))
+                        std::mem::transmute([<$flname _linenumber_align>](self.inner))
                     }
                 }
 
@@ -520,7 +520,7 @@ macro_rules! impl_display_ext {
                     }
                 }
 
-                fn wrap_mode(&mut self, wrap: crate::text::WrapMode, wrap_margin: i32) {
+                fn wrap_mode(&mut self, wrap: $crate::text::WrapMode, wrap_margin: i32) {
                     assert!(!self.was_deleted());
                     unsafe { [<$flname _wrap_mode>](self.inner, wrap as i32, wrap_margin) }
                 }

--- a/fltk/src/macros/group.rs
+++ b/fltk/src/macros/group.rs
@@ -1,3 +1,4 @@
+#[doc(hidden)]
 #[macro_export]
 /// Implements GroupExt
 macro_rules! impl_group_ext {
@@ -210,6 +211,7 @@ macro_rules! impl_group_ext {
 
 pub use impl_group_ext;
 
+#[doc(hidden)]
 #[macro_export]
 /// Implements GroupExt via a member
 macro_rules! impl_group_ext_via {

--- a/fltk/src/macros/group.rs
+++ b/fltk/src/macros/group.rs
@@ -3,11 +3,11 @@
 macro_rules! impl_group_ext {
     ($name: ident, $flname: ident) => {
         impl IntoIterator for $name {
-            type Item = Widget;
+            type Item = $crate::widget::Widget;
             type IntoIter = std::vec::IntoIter<Self::Item>;
 
             fn into_iter(self) -> Self::IntoIter {
-                let mut v: Vec<Widget> = vec![];
+                let mut v: Vec<$crate::widget::Widget> = vec![];
                 for i in 0..self.children() {
                     v.push(self.child(i).unwrap());
                 }
@@ -46,7 +46,7 @@ macro_rules! impl_group_ext {
                     }
                 }
 
-                fn child(&self, idx: i32) -> Option<Widget> {
+                fn child(&self, idx: i32) -> Option<$crate::widget::Widget> {
                     unsafe {
                         assert!(!self.was_deleted());
                         if idx >= self.children() || idx < 0 {
@@ -56,7 +56,7 @@ macro_rules! impl_group_ext {
                         if child_widget.is_null() {
                             None
                         } else {
-                            Some(Widget::from_widget_ptr(
+                            Some($crate::widget::Widget::from_widget_ptr(
                                 child_widget as *mut fltk_sys::widget::Fl_Widget,
                             ))
                         }
@@ -145,7 +145,7 @@ macro_rules! impl_group_ext {
                     assert!(!self.was_deleted());
                     assert!(!w.was_deleted());
                     unsafe {
-                        crate::app::open_display();
+                        $crate::app::open_display();
                         [<$flname _draw_child>](self.inner as _, w.as_widget_ptr() as _)
                     }
                 }
@@ -154,7 +154,7 @@ macro_rules! impl_group_ext {
                     assert!(!self.was_deleted());
                     assert!(!w.was_deleted());
                     unsafe {
-                        crate::app::open_display();
+                        $crate::app::open_display();
                         [<$flname _update_child>](self.inner as _, w.as_widget_ptr() as _)
                     }
                 }
@@ -163,7 +163,7 @@ macro_rules! impl_group_ext {
                     assert!(!self.was_deleted());
                     assert!(!w.was_deleted());
                     unsafe {
-                        crate::app::open_display();
+                        $crate::app::open_display();
                         [<$flname _draw_outside_label>](
                             self.inner as _,
                             w.as_widget_ptr() as _,
@@ -174,7 +174,7 @@ macro_rules! impl_group_ext {
                 fn draw_children(&mut self) {
                     assert!(!self.was_deleted());
                     unsafe {
-                        crate::app::open_display();
+                        $crate::app::open_display();
                         [<$flname _draw_children>](self.inner as _)
                     }
                 }
@@ -200,8 +200,8 @@ macro_rules! impl_group_ext {
                     vec
                 }
 
-                unsafe fn into_group(&self) -> crate::group::Group {
-                    crate::group::Group::from_widget_ptr(self.inner as _)
+                unsafe fn into_group(&self) -> $crate::group::Group {
+                    $crate::group::Group::from_widget_ptr(self.inner as _)
                 }
             }
         }
@@ -213,8 +213,8 @@ pub use impl_group_ext;
 #[macro_export]
 /// Implements GroupExt via a member
 macro_rules! impl_group_ext_via {
-    ($widget:ty, $member:tt) => {        
-        unsafe impl GroupExt for $widget {       
+    ($widget:ty, $member:tt) => {
+        unsafe impl GroupExt for $widget {
             fn begin(&self) {
                 self.$member.begin()
             }
@@ -235,7 +235,7 @@ macro_rules! impl_group_ext_via {
                 self.$member.children()
             }
 
-            fn child(&self, idx: i32) -> Option<Widget> {
+            fn child(&self, idx: i32) -> Option<$crate::widget::Widget> {
                 self.$member.child(idx)
             }
 
@@ -303,7 +303,7 @@ macro_rules! impl_group_ext_via {
                 self.$member.bounds()
             }
 
-            unsafe fn into_group(&self) -> crate::group::Group {
+            unsafe fn into_group(&self) -> $crate::group::Group {
                 self.$member.into_group()
             }
         }

--- a/fltk/src/macros/image.rs
+++ b/fltk/src/macros/image.rs
@@ -1,3 +1,4 @@
+#[doc(hidden)]
 #[macro_export]
 /// Implements ImageExt
 macro_rules! impl_image_ext {

--- a/fltk/src/macros/input.rs
+++ b/fltk/src/macros/input.rs
@@ -1,3 +1,4 @@
+#[doc(hidden)]
 #[macro_export]
 /// Implements InputExt
 macro_rules! impl_input_ext {

--- a/fltk/src/macros/input.rs
+++ b/fltk/src/macros/input.rs
@@ -9,7 +9,7 @@ macro_rules! impl_input_ext {
                         assert!(!self.was_deleted());
                         let value_ptr = [<$flname _value>](self.inner);
                         assert!(!value_ptr.is_null());
-                        CStr::from_ptr(value_ptr as *mut raw::c_char)
+                        CStr::from_ptr(value_ptr as *mut std::os::raw::c_char)
                             .to_string_lossy()
                             .to_string()
                     }
@@ -148,28 +148,28 @@ macro_rules! impl_input_ext {
                     }
                 }
 
-                fn text_font(&self) -> Font {
+                fn text_font(&self) -> $crate::enums::Font {
                     unsafe {
                         assert!(!self.was_deleted());
-                        mem::transmute([<$flname _text_font>](self.inner))
+                        std::mem::transmute([<$flname _text_font>](self.inner))
                     }
                 }
 
-                fn set_text_font(&mut self, font: Font) {
+                fn set_text_font(&mut self, font: $crate::enums::Font) {
                     unsafe {
                         assert!(!self.was_deleted());
                         [<$flname _set_text_font>](self.inner, font.bits() as i32)
                     }
                 }
 
-                fn text_color(&self) -> Color {
+                fn text_color(&self) -> $crate::enums::Color {
                     unsafe {
                         assert!(!self.was_deleted());
-                        mem::transmute([<$flname _text_color>](self.inner))
+                        std::mem::transmute([<$flname _text_color>](self.inner))
                     }
                 }
 
-                fn set_text_color(&mut self, color: Color) {
+                fn set_text_color(&mut self, color: $crate::enums::Color) {
                     unsafe {
                         assert!(!self.was_deleted());
                         [<$flname _set_text_color>](self.inner, color.bits() as u32)

--- a/fltk/src/macros/menu.rs
+++ b/fltk/src/macros/menu.rs
@@ -20,23 +20,23 @@ macro_rules! impl_menu_ext {
                 fn add<F: FnMut(&mut Self) + 'static>(
                     &mut self,
                     name: &str,
-                    shortcut: Shortcut,
+                    shortcut: $crate::enums::Shortcut,
                     flag: MenuFlag,
                     cb: F,
                 ) -> i32 {
                     assert!(!self.was_deleted());
                     let temp = CString::safe_new(name);
                     unsafe {
-                        unsafe extern "C" fn shim(wid: *mut Fl_Widget, data: *mut raw::c_void) {
-                            let mut wid = crate::widget::Widget::from_widget_ptr(wid as *mut _);
-                            let a: *mut Box<dyn FnMut(&mut crate::widget::Widget)> =
-                                data as *mut Box<dyn FnMut(&mut crate::widget::Widget)>;
-                            let f: &mut (dyn FnMut(&mut crate::widget::Widget)) = &mut **a;
+                        unsafe extern "C" fn shim(wid: *mut Fl_Widget, data: *mut std::os::raw::c_void) {
+                            let mut wid = $crate::widget::Widget::from_widget_ptr(wid as *mut _);
+                            let a: *mut Box<dyn FnMut(&mut $crate::widget::Widget)> =
+                                data as *mut Box<dyn FnMut(&mut $crate::widget::Widget)>;
+                            let f: &mut (dyn FnMut(&mut $crate::widget::Widget)) = &mut **a;
                             let _ =
                                 std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| f(&mut wid)));
                         }
                         let a: *mut Box<dyn FnMut(&mut Self)> = Box::into_raw(Box::new(Box::new(cb)));
-                        let data: *mut raw::c_void = a as *mut raw::c_void;
+                        let data: *mut std::os::raw::c_void = a as *mut std::os::raw::c_void;
                         let callback: Fl_Callback = Some(shim);
                         [<$flname _add>](
                             self.inner,
@@ -53,23 +53,23 @@ macro_rules! impl_menu_ext {
                     &mut self,
                     idx: i32,
                     name: &str,
-                    shortcut: Shortcut,
+                    shortcut: $crate::enums::Shortcut,
                     flag: MenuFlag,
                     cb: F,
                 ) -> i32 {
                     assert!(!self.was_deleted());
                     let temp = CString::safe_new(name);
                     unsafe {
-                        unsafe extern "C" fn shim(wid: *mut Fl_Widget, data: *mut raw::c_void) {
-                            let mut wid = crate::widget::Widget::from_widget_ptr(wid as *mut _);
-                            let a: *mut Box<dyn FnMut(&mut crate::widget::Widget)> =
-                                data as *mut Box<dyn FnMut(&mut crate::widget::Widget)>;
-                            let f: &mut (dyn FnMut(&mut crate::widget::Widget)) = &mut **a;
+                        unsafe extern "C" fn shim(wid: *mut Fl_Widget, data: *mut std::os::raw::c_void) {
+                            let mut wid = $crate::widget::Widget::from_widget_ptr(wid as *mut _);
+                            let a: *mut Box<dyn FnMut(&mut $crate::widget::Widget)> =
+                                data as *mut Box<dyn FnMut(&mut $crate::widget::Widget)>;
+                            let f: &mut (dyn FnMut(&mut $crate::widget::Widget)) = &mut **a;
                             let _ =
                                 std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| f(&mut wid)));
                         }
                         let a: *mut Box<dyn FnMut(&mut Self)> = Box::into_raw(Box::new(Box::new(cb)));
-                        let data: *mut raw::c_void = a as *mut raw::c_void;
+                        let data: *mut std::os::raw::c_void = a as *mut std::os::raw::c_void;
                         let callback: Fl_Callback = Some(shim);
                         [<$flname _insert>](
                             self.inner,
@@ -86,9 +86,9 @@ macro_rules! impl_menu_ext {
                 fn add_emit<T: 'static + Clone + Send + Sync>(
                     &mut self,
                     label: &str,
-                    shortcut: Shortcut,
-                    flag: crate::menu::MenuFlag,
-                    sender: crate::app::Sender<T>,
+                    shortcut: $crate::enums::Shortcut,
+                    flag: $crate::menu::MenuFlag,
+                    sender: $crate::app::Sender<T>,
                     msg: T,
                 ) -> i32 {
                     self.add(label, shortcut, flag, move |_| sender.send(msg.clone()))
@@ -98,9 +98,9 @@ macro_rules! impl_menu_ext {
                     &mut self,
                     idx: i32,
                     label: &str,
-                    shortcut: Shortcut,
-                    flag: crate::menu::MenuFlag,
-                    sender: crate::app::Sender<T>,
+                    shortcut: $crate::enums::Shortcut,
+                    flag: $crate::menu::MenuFlag,
+                    sender: $crate::app::Sender<T>,
                     msg: T,
                 ) -> i32 {
                     self.insert(idx, label, shortcut, flag, move |_| {
@@ -147,14 +147,14 @@ macro_rules! impl_menu_ext {
                     unsafe { [<$flname _find_index>](self.inner, label.as_ptr()) as i32 }
                 }
 
-                fn text_font(&self) -> Font {
+                fn text_font(&self) -> $crate::enums::Font {
                     unsafe {
                         assert!(!self.was_deleted());
-                        mem::transmute([<$flname _text_font>](self.inner))
+                        std::mem::transmute([<$flname _text_font>](self.inner))
                     }
                 }
 
-                fn set_text_font(&mut self, c: Font) {
+                fn set_text_font(&mut self, c: $crate::enums::Font) {
                     unsafe {
                         assert!(!self.was_deleted());
                         [<$flname _set_text_font>](self.inner, c.bits() as i32)
@@ -175,14 +175,14 @@ macro_rules! impl_menu_ext {
                     }
                 }
 
-                fn text_color(&self) -> Color {
+                fn text_color(&self) -> $crate::enums::Color {
                     unsafe {
                         assert!(!self.was_deleted());
-                        mem::transmute([<$flname _text_color>](self.inner))
+                        std::mem::transmute([<$flname _text_color>](self.inner))
                     }
                 }
 
-                fn set_text_color(&mut self, c: Color) {
+                fn set_text_color(&mut self, c: $crate::enums::Color) {
                     unsafe {
                         assert!(!self.was_deleted());
                         [<$flname _set_text_color>](self.inner, c.bits() as u32)
@@ -195,7 +195,7 @@ macro_rules! impl_menu_ext {
                         let arg2 = CString::safe_new(text);
                         [<$flname _add_choice>](
                             self.inner,
-                            arg2.as_ptr() as *mut raw::c_char,
+                            arg2.as_ptr() as *mut std::os::raw::c_char,
                         )
                     }
                 }
@@ -208,7 +208,7 @@ macro_rules! impl_menu_ext {
                             None
                         } else {
                             Some(
-                                CStr::from_ptr(choice_ptr as *mut raw::c_char)
+                                CStr::from_ptr(choice_ptr as *mut std::os::raw::c_char)
                                     .to_string_lossy()
                                     .to_string(),
                             )
@@ -300,7 +300,7 @@ macro_rules! impl_menu_ext {
                             None
                         } else {
                             Some(
-                                CStr::from_ptr(text as *mut raw::c_char)
+                                CStr::from_ptr(text as *mut std::os::raw::c_char)
                                     .to_string_lossy()
                                     .to_string(),
                             )
@@ -308,7 +308,7 @@ macro_rules! impl_menu_ext {
                     }
                 }
 
-                fn at(&self, idx: i32) -> Option<crate::menu::MenuItem> {
+                fn at(&self, idx: i32) -> Option<$crate::menu::MenuItem> {
                     assert!(!self.was_deleted());
                     if idx >= self.size() || idx < 0 {
                         return None;
@@ -327,12 +327,12 @@ macro_rules! impl_menu_ext {
                     }
                 }
 
-                fn mode(&self, idx: i32) -> crate::menu::MenuFlag {
+                fn mode(&self, idx: i32) -> $crate::menu::MenuFlag {
                     assert!(!self.was_deleted());
-                    unsafe { mem::transmute([<$flname _mode>](self.inner, idx as i32)) }
+                    unsafe { std::mem::transmute([<$flname _mode>](self.inner, idx as i32)) }
                 }
 
-                fn set_mode(&mut self, idx: i32, flag: crate::menu::MenuFlag) {
+                fn set_mode(&mut self, idx: i32, flag: $crate::menu::MenuFlag) {
                     assert!(!self.was_deleted());
                     unsafe { [<$flname _set_mode>](self.inner, idx as i32, flag as i32) }
                 }
@@ -341,14 +341,14 @@ macro_rules! impl_menu_ext {
                     //
                 }
 
-                fn set_down_frame(&mut self, f: FrameType) {
+                fn set_down_frame(&mut self, f: $crate::enums::FrameType) {
                     assert!(!self.was_deleted());
                     unsafe { [<$flname _set_down_box>](self.inner, f as i32) }
                 }
 
-                fn down_frame(&self) -> FrameType {
+                fn down_frame(&self) -> $crate::enums::FrameType {
                     assert!(!self.was_deleted());
-                    unsafe { mem::transmute([<$flname _down_box>](self.inner)) }
+                    unsafe { std::mem::transmute([<$flname _down_box>](self.inner)) }
                 }
 
                 fn global(&mut self) {
@@ -356,7 +356,7 @@ macro_rules! impl_menu_ext {
                     unsafe { [<$flname _global>](self.inner) }
                 }
 
-                fn menu(&self) -> Option<crate::menu::MenuItem> {
+                fn menu(&self) -> Option<$crate::menu::MenuItem> {
                     assert!(!self.was_deleted());
                     unsafe {
                         let ptr = [<$flname _menu>](self.inner);
@@ -371,7 +371,7 @@ macro_rules! impl_menu_ext {
                     }
                 }
 
-                unsafe fn set_menu(&mut self, item: crate::menu::MenuItem) {
+                unsafe fn set_menu(&mut self, item: $crate::menu::MenuItem) {
                     assert!(!self.was_deleted());
                     [<$flname _set_menu>](self.inner, item.inner)
                 }

--- a/fltk/src/macros/menu.rs
+++ b/fltk/src/macros/menu.rs
@@ -1,3 +1,4 @@
+#[doc(hidden)]
 #[macro_export]
 /// Implements MenuExt
 macro_rules! impl_menu_ext {

--- a/fltk/src/macros/mod.rs
+++ b/fltk/src/macros/mod.rs
@@ -1,43 +1,32 @@
-#[doc(hidden)]
 /// Provides the default implementation macro for browser widgets
 pub mod browser;
 
-#[doc(hidden)]
 /// Provides the default implementation macro for button widgets
 pub mod button;
 
-#[doc(hidden)]
 /// Provides the default implementation macro for display widgets
 pub mod display;
 
-#[doc(hidden)]
 /// Provides the default implementation macro for group widgets
 pub mod group;
 
-#[doc(hidden)]
 /// Provides the default implementation macro for image widgets
 pub mod image;
 
-#[doc(hidden)]
 /// Provides the default implementation macro for input widgets
 pub mod input;
 
-#[doc(hidden)]
 /// Provides the default implementation macro for menu widgets
 pub mod menu;
 
-#[doc(hidden)]
 /// Provides the default implementation macro for table widgets
 pub mod table;
 
-#[doc(hidden)]
 /// Provides the default implementation macro for valuator widgets
 pub mod valuator;
 
-#[doc(hidden)]
 /// Provides the default implementation macro for widget widgets
 pub mod widget;
 
-#[doc(hidden)]
 /// Provides the default implementation macro for window widgets
 pub mod window;

--- a/fltk/src/macros/table.rs
+++ b/fltk/src/macros/table.rs
@@ -11,17 +11,17 @@ macro_rules! impl_table_ext {
                     }
                 }
 
-                fn set_table_frame(&mut self, frame: FrameType) {
+                fn set_table_frame(&mut self, frame: $crate::enums::FrameType) {
                     unsafe {
                         assert!(!self.was_deleted());
                         [<$flname _set_table_box>](self.inner, frame as i32)
                     }
                 }
 
-                fn table_frame(&self) -> FrameType {
+                fn table_frame(&self) -> $crate::enums::FrameType {
                     unsafe {
                         assert!(!self.was_deleted());
-                        mem::transmute([<$flname _table_box>](self.inner))
+                        std::mem::transmute([<$flname _table_box>](self.inner))
                     }
                 }
 
@@ -190,31 +190,31 @@ macro_rules! impl_table_ext {
                     }
                 }
 
-                fn set_row_header_color(&mut self, val: Color) {
+                fn set_row_header_color(&mut self, val: $crate::enums::Color) {
                     unsafe {
                         assert!(!self.was_deleted());
                         [<$flname _set_row_header_color>](self.inner, val.bits() as u32)
                     }
                 }
 
-                fn row_header_color(&self) -> Color {
+                fn row_header_color(&self) -> $crate::enums::Color {
                     unsafe {
                         assert!(!self.was_deleted());
-                        mem::transmute([<$flname _row_header_color>](self.inner))
+                        std::mem::transmute([<$flname _row_header_color>](self.inner))
                     }
                 }
 
-                fn set_col_header_color(&mut self, val: Color) {
+                fn set_col_header_color(&mut self, val: $crate::enums::Color) {
                     unsafe {
                         assert!(!self.was_deleted());
                         [<$flname _set_col_header_color>](self.inner, val.bits() as u32)
                     }
                 }
 
-                fn col_header_color(&self) -> Color {
+                fn col_header_color(&self) -> $crate::enums::Color {
                     unsafe {
                         assert!(!self.was_deleted());
-                        mem::transmute([<$flname _col_header_color>](self.inner))
+                        std::mem::transmute([<$flname _col_header_color>](self.inner))
                     }
                 }
 
@@ -401,7 +401,7 @@ macro_rules! impl_table_ext {
                 }
 
                 fn draw_cell<
-                    F: FnMut(&mut Self, crate::table::TableContext, i32, i32, i32, i32, i32, i32)
+                    F: FnMut(&mut Self, $crate::table::TableContext, i32, i32, i32, i32, i32, i32)
                         + 'static,
                 >(
                     &mut self,
@@ -411,34 +411,34 @@ macro_rules! impl_table_ext {
                     pub type CustomDrawCellCallback = Option<
                         unsafe extern "C" fn(
                             wid: *mut Fl_Widget,
-                            ctx: raw::c_int,
-                            arg2: raw::c_int,
-                            arg3: raw::c_int,
-                            arg4: raw::c_int,
-                            arg5: raw::c_int,
-                            arg6: raw::c_int,
-                            arg7: raw::c_int,
-                            data: *mut raw::c_void,
+                            ctx: std::os::raw::c_int,
+                            arg2: std::os::raw::c_int,
+                            arg3: std::os::raw::c_int,
+                            arg4: std::os::raw::c_int,
+                            arg5: std::os::raw::c_int,
+                            arg6: std::os::raw::c_int,
+                            arg7: std::os::raw::c_int,
+                            data: *mut std::os::raw::c_void,
                         ),
                     >;
                     unsafe {
                         unsafe extern "C" fn shim(
                             wid: *mut Fl_Widget,
-                            ctx: raw::c_int,
-                            arg2: raw::c_int,
-                            arg3: raw::c_int,
-                            arg4: raw::c_int,
-                            arg5: raw::c_int,
-                            arg6: raw::c_int,
-                            arg7: raw::c_int,
-                            data: *mut raw::c_void,
+                            ctx: std::os::raw::c_int,
+                            arg2: std::os::raw::c_int,
+                            arg3: std::os::raw::c_int,
+                            arg4: std::os::raw::c_int,
+                            arg5: std::os::raw::c_int,
+                            arg6: std::os::raw::c_int,
+                            arg7: std::os::raw::c_int,
+                            data: *mut std::os::raw::c_void,
                         ) {
                             let mut wid = $name::from_widget_ptr(wid as *mut _);
-                            let ctx: TableContext = mem::transmute(ctx);
+                            let ctx: TableContext = std::mem::transmute(ctx);
                             let a: *mut Box<
                                 dyn FnMut(
                                     &mut $name,
-                                    crate::table::TableContext,
+                                    $crate::table::TableContext,
                                     i32,
                                     i32,
                                     i32,
@@ -449,7 +449,7 @@ macro_rules! impl_table_ext {
                             > = data as *mut Box<
                                 dyn FnMut(
                                     &mut $name,
-                                    crate::table::TableContext,
+                                    $crate::table::TableContext,
                                     i32,
                                     i32,
                                     i32,
@@ -460,7 +460,7 @@ macro_rules! impl_table_ext {
                             >;
                             let f: &mut (dyn FnMut(
                                 &mut $name,
-                                crate::table::TableContext,
+                                $crate::table::TableContext,
                                 i32,
                                 i32,
                                 i32,
@@ -476,7 +476,7 @@ macro_rules! impl_table_ext {
                         let a: *mut Box<
                             dyn FnMut(
                                 &mut Self,
-                                crate::table::TableContext,
+                                $crate::table::TableContext,
                                 i32,
                                 i32,
                                 i32,
@@ -485,7 +485,7 @@ macro_rules! impl_table_ext {
                                 i32,
                             ),
                         > = Box::into_raw(Box::new(Box::new(cb)));
-                        let data: *mut raw::c_void = a as *mut raw::c_void;
+                        let data: *mut std::os::raw::c_void = a as *mut std::os::raw::c_void;
                         let callback: CustomDrawCellCallback = Some(shim);
                         [<$flname _draw_cell>](self.inner, callback, data);
                     }
@@ -511,26 +511,26 @@ macro_rules! impl_table_ext {
                 }
 
                 fn callback_context(&self) -> TableContext {
-                    unsafe { mem::transmute([<$flname _callback_context>](self.inner)) }
+                    unsafe { std::mem::transmute([<$flname _callback_context>](self.inner)) }
                 }
 
-                fn scrollbar(&self) -> crate::valuator::Scrollbar {
+                fn scrollbar(&self) -> $crate::valuator::Scrollbar {
                     assert!(!self.was_deleted());
                     unsafe {
                         let ptr = [<$flname _scrollbar>](self.inner);
                         assert!(!ptr.is_null());
-                        crate::valuator::Scrollbar::from_widget_ptr(
+                        $crate::valuator::Scrollbar::from_widget_ptr(
                             ptr as *mut fltk_sys::widget::Fl_Widget,
                         )
                     }
                 }
 
-                fn hscrollbar(&self) -> crate::valuator::Scrollbar {
+                fn hscrollbar(&self) -> $crate::valuator::Scrollbar {
                     assert!(!self.was_deleted());
                     unsafe {
                         let ptr = [<$flname _hscrollbar>](self.inner);
                         assert!(!ptr.is_null());
-                        crate::valuator::Scrollbar::from_widget_ptr(
+                        $crate::valuator::Scrollbar::from_widget_ptr(
                             ptr as *mut fltk_sys::widget::Fl_Widget,
                         )
                     }

--- a/fltk/src/macros/table.rs
+++ b/fltk/src/macros/table.rs
@@ -1,3 +1,4 @@
+#[doc(hidden)]
 #[macro_export]
 /// Implements TableExt
 macro_rules! impl_table_ext {

--- a/fltk/src/macros/valuator.rs
+++ b/fltk/src/macros/valuator.rs
@@ -88,7 +88,7 @@ macro_rules! impl_valuator_ext {
                         let arg2 = CString::safe_new(arg2);
                         let x = [<$flname _format>](
                             self.inner,
-                            arg2.as_ptr() as *mut raw::c_char,
+                            arg2.as_ptr() as *mut std::os::raw::c_char,
                         );
                         if x < 0 {
                             return Err(FltkError::Internal(FltkErrorKind::FailedOperation));

--- a/fltk/src/macros/valuator.rs
+++ b/fltk/src/macros/valuator.rs
@@ -1,3 +1,4 @@
+#[doc(hidden)]
 #[macro_export]
 /// Implements ValuatorExt
 macro_rules! impl_valuator_ext {

--- a/fltk/src/macros/widget.rs
+++ b/fltk/src/macros/widget.rs
@@ -1,3 +1,4 @@
+#[doc(hidden)]
 #[macro_export]
 /// Implements WidgetExt
 macro_rules! impl_widget_ext {
@@ -863,6 +864,7 @@ macro_rules! impl_widget_ext {
     };
 }
 
+#[doc(hidden)]
 #[macro_export]
 /// Implements WidgetBase
 macro_rules! impl_widget_base {
@@ -1060,6 +1062,7 @@ macro_rules! impl_widget_base {
     };
 }
 
+#[doc(hidden)]
 #[macro_export]
 /// Implements WidgetType
 macro_rules! impl_widget_type {
@@ -1080,6 +1083,7 @@ pub use impl_widget_base;
 pub use impl_widget_ext;
 pub use impl_widget_type;
 
+#[doc(hidden)]
 #[macro_export]
 /// Implements WidgetExt via a member
 macro_rules! impl_widget_ext_via {
@@ -1506,6 +1510,7 @@ macro_rules! impl_widget_ext_via {
     };
 }
 
+#[doc(hidden)]
 #[macro_export]
 /// Implements WidgetBase via a member
 macro_rules! impl_widget_base_via {

--- a/fltk/src/macros/widget.rs
+++ b/fltk/src/macros/widget.rs
@@ -51,7 +51,7 @@ macro_rules! impl_widget_ext {
                     self
                 }
 
-                fn with_align(mut self, align: Align) -> Self {
+                fn with_align(mut self, align: $crate::enums::Align) -> Self {
                     self.set_align(align);
                     self
                 }
@@ -285,7 +285,7 @@ macro_rules! impl_widget_ext {
                     assert!(!self.was_deleted());
                     unsafe {
                         fltk_sys::fl::Fl_lock();
-                        let ptr = [<$flname _label>](self.inner) as *mut raw::c_char;
+                        let ptr = [<$flname _label>](self.inner) as *mut std::os::raw::c_char;
                         let s = if ptr.is_null() {
                             String::from("")
                         } else {
@@ -344,7 +344,7 @@ macro_rules! impl_widget_ext {
                             None
                         } else {
                             Some(
-                                CStr::from_ptr(tooltip_ptr as *mut raw::c_char)
+                                CStr::from_ptr(tooltip_ptr as *mut std::os::raw::c_char)
                                     .to_string_lossy()
                                     .to_string(),
                             )
@@ -360,39 +360,39 @@ macro_rules! impl_widget_ext {
                     unsafe {
                         [<$flname _set_tooltip>](
                             self.inner,
-                            txt.as_ptr() as *mut raw::c_char,
+                            txt.as_ptr() as *mut std::os::raw::c_char,
                         )
                     }
                 }
 
-                fn color(&self) -> Color {
+                fn color(&self) -> $crate::enums::Color {
                     assert!(!self.was_deleted());
-                    unsafe { mem::transmute([<$flname _color>](self.inner)) }
+                    unsafe { std::mem::transmute([<$flname _color>](self.inner)) }
                 }
 
-                fn set_color(&mut self, color: Color) {
+                fn set_color(&mut self, color: $crate::enums::Color) {
                     assert!(!self.was_deleted());
                     unsafe { [<$flname _set_color>](self.inner, color.bits() as u32) }
                 }
 
-                fn label_color(&self) -> Color {
+                fn label_color(&self) -> $crate::enums::Color {
                     assert!(!self.was_deleted());
-                    unsafe { mem::transmute([<$flname _label_color>](self.inner)) }
+                    unsafe { std::mem::transmute([<$flname _label_color>](self.inner)) }
                 }
 
-                fn set_label_color(&mut self, color: Color) {
+                fn set_label_color(&mut self, color: $crate::enums::Color) {
                     assert!(!self.was_deleted());
                     unsafe {
                         [<$flname _set_label_color>](self.inner, color.bits() as u32)
                     }
                 }
 
-                fn label_font(&self) -> Font {
+                fn label_font(&self) -> $crate::enums::Font {
                     assert!(!self.was_deleted());
-                    unsafe { mem::transmute([<$flname _label_font>](self.inner)) }
+                    unsafe { std::mem::transmute([<$flname _label_font>](self.inner)) }
                 }
 
-                fn set_label_font(&mut self, font: Font) {
+                fn set_label_font(&mut self, font: $crate::enums::Font) {
                     assert!(!self.was_deleted());
                     unsafe { [<$flname _set_label_font>](self.inner, font.bits() as i32) }
                 }
@@ -408,24 +408,24 @@ macro_rules! impl_widget_ext {
                     unsafe { [<$flname _set_label_size>](self.inner, sz) }
                 }
 
-                fn label_type(&self) -> LabelType {
+                fn label_type(&self) -> $crate::enums::LabelType {
                     assert!(!self.was_deleted());
-                    unsafe { mem::transmute([<$flname _label_type>](self.inner)) }
+                    unsafe { std::mem::transmute([<$flname _label_type>](self.inner)) }
                 }
 
-                fn set_label_type(&mut self, typ: LabelType) {
+                fn set_label_type(&mut self, typ: $crate::enums::LabelType) {
                     assert!(!self.was_deleted());
                     unsafe {
                         [<$flname _set_label_type>](self.inner, typ as i32);
                     }
                 }
 
-                fn frame(&self) -> FrameType {
+                fn frame(&self) -> $crate::enums::FrameType {
                     assert!(!self.was_deleted());
-                    unsafe { mem::transmute([<$flname _box>](self.inner)) }
+                    unsafe { std::mem::transmute([<$flname _box>](self.inner)) }
                 }
 
-                fn set_frame(&mut self, typ: FrameType) {
+                fn set_frame(&mut self, typ: $crate::enums::FrameType) {
                     assert!(!self.was_deleted());
                     unsafe {
                         [<$flname _set_box>](self.inner, typ as i32);
@@ -447,44 +447,44 @@ macro_rules! impl_widget_ext {
                     unsafe { [<$flname _clear_changed>](self.inner) }
                 }
 
-                fn align(&self) -> Align {
+                fn align(&self) -> $crate::enums::Align {
                     assert!(!self.was_deleted());
-                    unsafe { mem::transmute([<$flname _align>](self.inner)) }
+                    unsafe { std::mem::transmute([<$flname _align>](self.inner)) }
                 }
 
-                fn set_align(&mut self, align: Align) {
+                fn set_align(&mut self, align: $crate::enums::Align) {
                     assert!(!self.was_deleted());
                     unsafe { [<$flname _set_align>](self.inner, align.bits() as i32) }
                 }
 
-                fn set_trigger(&mut self, trigger: CallbackTrigger) {
+                fn set_trigger(&mut self, trigger: $crate::enums::CallbackTrigger) {
                     assert!(!self.was_deleted());
                     unsafe { [<$flname _set_when>](self.inner, trigger.bits() as i32) }
                 }
 
-                fn trigger(&self) -> CallbackTrigger {
+                fn trigger(&self) -> $crate::enums::CallbackTrigger {
                     assert!(!self.was_deleted());
-                    unsafe { mem::transmute([<$flname _when>](self.inner)) }
+                    unsafe { std::mem::transmute([<$flname _when>](self.inner)) }
                 }
 
-                fn parent(&self) -> Option<crate::group::Group> {
+                fn parent(&self) -> Option<$crate::group::Group> {
                     assert!(!self.was_deleted());
                     unsafe {
                         let x = [<$flname _parent>](self.inner);
                         if x.is_null() {
                             None
                         } else {
-                            Some(crate::group::Group::from_widget_ptr(x as *mut _))
+                            Some($crate::group::Group::from_widget_ptr(x as *mut _))
                         }
                     }
                 }
 
-                fn selection_color(&mut self) -> Color {
+                fn selection_color(&mut self) -> $crate::enums::Color {
                     assert!(!self.was_deleted());
-                    unsafe { mem::transmute([<$flname _selection_color>](self.inner)) }
+                    unsafe { std::mem::transmute([<$flname _selection_color>](self.inner)) }
                 }
 
-                fn set_selection_color(&mut self, color: Color) {
+                fn set_selection_color(&mut self, color: $crate::enums::Color) {
                     assert!(!self.was_deleted());
                     unsafe {
                         [<$flname _set_selection_color>](self.inner, color.bits() as u32);
@@ -505,7 +505,7 @@ macro_rules! impl_widget_ext {
                         if wind_ptr.is_null() {
                             None
                         } else {
-                            Some(Box::new(Window::from_widget_ptr(
+                            Some(Box::new($crate::window::Window::from_widget_ptr(
                                 wind_ptr as *mut fltk_sys::widget::Fl_Widget,
                             )))
                         }
@@ -519,7 +519,7 @@ macro_rules! impl_widget_ext {
                         if wind_ptr.is_null() {
                             None
                         } else {
-                            Some(Box::new(Window::from_widget_ptr(
+                            Some(Box::new($crate::window::Window::from_widget_ptr(
                                 wind_ptr as *mut fltk_sys::widget::Fl_Widget,
                             )))
                         }
@@ -605,12 +605,12 @@ macro_rules! impl_widget_ext {
                     unsafe { [<$flname _set_damage>](self.inner, flag) }
                 }
 
-                fn damage_type(&self) -> Damage {
+                fn damage_type(&self) -> $crate::enums::Damage {
                     assert!(!self.was_deleted());
-                    unsafe { mem::transmute([<$flname _damage>](self.inner)) }
+                    unsafe { std::mem::transmute([<$flname _damage>](self.inner)) }
                 }
 
-                fn set_damage_type(&mut self, mask: Damage) {
+                fn set_damage_type(&mut self, mask: $crate::enums::Damage) {
                     assert!(!self.was_deleted());
                     unsafe { [<$flname _set_damage>](self.inner, mask.bits()) }
                 }
@@ -627,20 +627,20 @@ macro_rules! impl_widget_ext {
                         if ptr.is_null() {
                             return None;
                         }
-                        Some(Box::new(Window::from_widget_ptr(
+                        Some(Box::new($crate::window::Window::from_widget_ptr(
                             ptr as *mut fltk_sys::widget::Fl_Widget,
                         )))
                     }
                 }
 
-                fn as_group(&self) -> Option<crate::group::Group> {
+                fn as_group(&self) -> Option<$crate::group::Group> {
                     assert!(!self.was_deleted());
                     unsafe {
                         let ptr = [<$flname _as_group>](self.inner);
                         if ptr.is_null() {
                             return None;
                         }
-                        Some(crate::group::Group::from_widget_ptr(
+                        Some($crate::group::Group::from_widget_ptr(
                             ptr as *mut fltk_sys::widget::Fl_Widget,
                         ))
                     }
@@ -652,7 +652,7 @@ macro_rules! impl_widget_ext {
                     unsafe {
                         [<$flname _inside>](
                             self.inner,
-                            wid.as_widget_ptr() as *mut raw::c_void,
+                            wid.as_widget_ptr() as *mut std::os::raw::c_void,
                         ) != 0
                     }
                 }
@@ -683,7 +683,7 @@ macro_rules! impl_widget_ext {
                         unsafe {
                             [<$flname _set_image>](
                                 self.inner,
-                                std::ptr::null_mut() as *mut raw::c_void,
+                                std::ptr::null_mut() as *mut std::os::raw::c_void,
                             )
                         }
                     }
@@ -704,7 +704,7 @@ macro_rules! impl_widget_ext {
                         unsafe {
                             [<$flname _set_image>](
                                 self.inner,
-                                std::ptr::null_mut() as *mut raw::c_void,
+                                std::ptr::null_mut() as *mut std::os::raw::c_void,
                             )
                         }
                     }
@@ -718,7 +718,7 @@ macro_rules! impl_widget_ext {
                             None
                         } else {
                             let img =
-                                Image::from_image_ptr(image_ptr as *mut fltk_sys::image::Fl_Image);
+                            $crate::image::Image::from_image_ptr(image_ptr as *mut fltk_sys::image::Fl_Image);
                             Some(Box::new(img))
                         }
                     }
@@ -738,7 +738,7 @@ macro_rules! impl_widget_ext {
                         unsafe {
                             [<$flname _set_deimage>](
                                 self.inner,
-                                std::ptr::null_mut() as *mut raw::c_void,
+                                std::ptr::null_mut() as *mut std::os::raw::c_void,
                             )
                         }
                     }
@@ -759,7 +759,7 @@ macro_rules! impl_widget_ext {
                         unsafe {
                             [<$flname _set_deimage>](
                                 self.inner,
-                                std::ptr::null_mut() as *mut raw::c_void,
+                                std::ptr::null_mut() as *mut std::os::raw::c_void,
                             )
                         }
                     }
@@ -773,7 +773,7 @@ macro_rules! impl_widget_ext {
                             None
                         } else {
                             let img =
-                                Image::from_image_ptr(image_ptr as *mut fltk_sys::image::Fl_Image);
+                            $crate::image::Image::from_image_ptr(image_ptr as *mut fltk_sys::image::Fl_Image);
                             Some(Box::new(img))
                         }
                     }
@@ -782,7 +782,7 @@ macro_rules! impl_widget_ext {
                 fn set_callback<F: FnMut(&mut Self) + 'static>(&mut self, cb: F) {
                     assert!(!self.was_deleted());
                     unsafe {
-                        unsafe extern "C" fn shim(wid: *mut Fl_Widget, data: *mut raw::c_void) {
+                        unsafe extern "C" fn shim(wid: *mut Fl_Widget, data: *mut std::os::raw::c_void) {
                             let mut wid = $name::from_widget_ptr(wid as *mut _);
                             let a = data as *mut Box<dyn FnMut(&mut $name)>;
                             let f: &mut (dyn FnMut(&mut $name)) = &mut **a;
@@ -791,7 +791,7 @@ macro_rules! impl_widget_ext {
                         }
                         let _old_data = self.user_data();
                         let a: *mut Box<dyn FnMut(&mut Self)> = Box::into_raw(Box::new(Box::new(cb)));
-                        let data: *mut raw::c_void = a as *mut raw::c_void;
+                        let data: *mut std::os::raw::c_void = a as *mut std::os::raw::c_void;
                         let callback: Fl_Callback = Some(shim);
                         [<$flname _set_callback>](self.inner, callback, data);
                     }
@@ -799,7 +799,7 @@ macro_rules! impl_widget_ext {
 
                 fn emit<T: 'static + Clone + Send + Sync>(
                     &mut self,
-                    sender: crate::app::Sender<T>,
+                    sender: $crate::app::Sender<T>,
                     msg: T,
                 ) {
                     assert!(!self.was_deleted());
@@ -854,7 +854,7 @@ macro_rules! impl_widget_ext {
                     }
                 }
 
-                fn handle_event(&mut self, event: Event) {
+                fn handle_event(&mut self, event: $crate::enums::Event) {
                     assert!(!self.was_deleted());
                     unsafe { [<$flname _handle_event>](self.inner, event.bits()) }
                 }
@@ -894,7 +894,7 @@ macro_rules! impl_widget_base {
                             widget_ptr as *mut fltk_sys::fl::Fl_Widget,
                         );
                         assert!(!tracker.is_null());
-                        unsafe extern "C" fn shim(data: *mut raw::c_void) {
+                        unsafe extern "C" fn shim(data: *mut std::os::raw::c_void) {
                             if !data.is_null() {
                                 let x = data as *mut Box<dyn FnMut()>;
                                 let _x = Box::from_raw(x);
@@ -946,20 +946,20 @@ macro_rules! impl_widget_base {
                     Self::from_widget_ptr(w.as_widget_ptr() as *mut _)
                 }
 
-                fn handle<F: FnMut(&mut Self, Event) -> bool + 'static>(&mut self, cb: F) {
+                fn handle<F: FnMut(&mut Self, $crate::enums::Event) -> bool + 'static>(&mut self, cb: F) {
                     assert!(!self.was_deleted());
                     assert!(self.is_derived);
                     unsafe {
                         unsafe extern "C" fn shim(
                             wid: *mut Fl_Widget,
                             ev: std::os::raw::c_int,
-                            data: *mut raw::c_void,
+                            data: *mut std::os::raw::c_void,
                         ) -> i32 {
                             let mut wid = $name::from_widget_ptr(wid as *mut _);
-                            let ev: Event = mem::transmute(ev);
-                            let a: *mut Box<dyn FnMut(&mut $name, Event) -> bool> =
-                                data as *mut Box<dyn FnMut(&mut $name, Event) -> bool>;
-                            let f: &mut (dyn FnMut(&mut $name, Event) -> bool) = &mut **a;
+                            let ev: $crate::enums::Event = std::mem::transmute(ev);
+                            let a: *mut Box<dyn FnMut(&mut $name, $crate::enums::Event) -> bool> =
+                                data as *mut Box<dyn FnMut(&mut $name, $crate::enums::Event) -> bool>;
+                            let f: &mut (dyn FnMut(&mut $name, $crate::enums::Event) -> bool) = &mut **a;
                             let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                                 match f(&mut wid, ev) {
                                     true => return 1,
@@ -973,9 +973,9 @@ macro_rules! impl_widget_base {
                             }
                         }
                         let _old_data = self.handle_data();
-                        let a: *mut Box<dyn FnMut(&mut Self, Event) -> bool> =
+                        let a: *mut Box<dyn FnMut(&mut Self, $crate::enums::Event) -> bool> =
                             Box::into_raw(Box::new(Box::new(cb)));
-                        let data: *mut raw::c_void = a as *mut raw::c_void;
+                        let data: *mut std::os::raw::c_void = a as *mut std::os::raw::c_void;
                         let callback: custom_handler_callback = Some(shim);
                         [<$flname _handle>](self.inner, callback, data);
                     }
@@ -985,7 +985,7 @@ macro_rules! impl_widget_base {
                     assert!(!self.was_deleted());
                     assert!(self.is_derived);
                     unsafe {
-                        unsafe extern "C" fn shim(wid: *mut Fl_Widget, data: *mut raw::c_void) {
+                        unsafe extern "C" fn shim(wid: *mut Fl_Widget, data: *mut std::os::raw::c_void) {
                             let mut wid = $name::from_widget_ptr(wid as *mut _);
                             let a: *mut Box<dyn FnMut(&mut $name)> =
                                 data as *mut Box<dyn FnMut(&mut $name)>;
@@ -995,7 +995,7 @@ macro_rules! impl_widget_base {
                         }
                         let _old_data = self.draw_data();
                         let a: *mut Box<dyn FnMut(&mut Self)> = Box::into_raw(Box::new(Box::new(cb)));
-                        let data: *mut raw::c_void = a as *mut raw::c_void;
+                        let data: *mut std::os::raw::c_void = a as *mut std::os::raw::c_void;
                         let callback: custom_draw_callback = Some(shim);
                         [<$flname _draw>](self.inner, callback, data);
                     }
@@ -1012,12 +1012,12 @@ macro_rules! impl_widget_base {
                     Some(*data)
                 }
 
-                unsafe fn handle_data(&mut self) -> Option<Box<dyn FnMut(Event) -> bool>> {
+                unsafe fn handle_data(&mut self) -> Option<Box<dyn FnMut($crate::enums::Event) -> bool>> {
                     let ptr = [<$flname _handle_data>](self.inner);
                     if ptr.is_null() {
                         return None;
                     }
-                    let data = ptr as *mut Box<dyn FnMut(Event) -> bool>;
+                    let data = ptr as *mut Box<dyn FnMut($crate::enums::Event) -> bool>;
                     let data = Box::from_raw(data);
                     [<$flname _handle>](self.inner, None, std::ptr::null_mut());
                     Some(*data)
@@ -1036,7 +1036,7 @@ macro_rules! impl_widget_base {
                             y: i32,
                             w: i32,
                             h: i32,
-                            data: *mut raw::c_void,
+                            data: *mut std::os::raw::c_void,
                         ) {
                             let mut wid = $name::from_widget_ptr(wid as *mut _);
                             let a: *mut Box<dyn FnMut(&mut $name, i32, i32, i32, i32)> =
@@ -1048,9 +1048,9 @@ macro_rules! impl_widget_base {
                         }
                         let a: *mut Box<dyn FnMut(&mut Self, i32, i32, i32, i32)> =
                             Box::into_raw(Box::new(Box::new(cb)));
-                        let data: *mut raw::c_void = a as *mut raw::c_void;
+                        let data: *mut std::os::raw::c_void = a as *mut std::os::raw::c_void;
                         let callback: Option<
-                            unsafe extern "C" fn(*mut Fl_Widget, i32, i32, i32, i32, *mut raw::c_void),
+                            unsafe extern "C" fn(*mut Fl_Widget, i32, i32, i32, i32, *mut std::os::raw::c_void),
                         > = Some(shim);
                         [<$flname _resize_callback>](self.inner, callback, data);
                     }
@@ -1070,7 +1070,7 @@ macro_rules! impl_widget_type {
             }
 
             fn from_i32(val: i32) -> $name {
-                unsafe { mem::transmute(val) }
+                unsafe { std::mem::transmute(val) }
             }
         }
     };
@@ -1079,7 +1079,6 @@ macro_rules! impl_widget_type {
 pub use impl_widget_base;
 pub use impl_widget_ext;
 pub use impl_widget_type;
-
 
 #[macro_export]
 /// Implements WidgetExt via a member
@@ -1101,7 +1100,7 @@ macro_rules! impl_widget_ext_via {
                 self
             }
 
-            fn with_align(mut self, align: Align) -> Self {
+            fn with_align(mut self, align: $crate::enums::Align) -> Self {
                 self.$member = self.$member.with_align(align);
                 self
             }
@@ -1217,7 +1216,7 @@ macro_rules! impl_widget_ext_via {
                 self.$member.measure_label()
             }
 
-            unsafe fn as_widget_ptr(&self) -> crate::app::WidgetPtr {
+            unsafe fn as_widget_ptr(&self) -> $crate::app::WidgetPtr {
                 self.$member.as_widget_ptr()
             }
 
@@ -1266,7 +1265,7 @@ macro_rules! impl_widget_ext_via {
 
             fn emit<T: 'static + Clone + Send + Sync>(
                 &mut self,
-                sender: crate::app::Sender<T>,
+                sender: $crate::app::Sender<T>,
                 msg: T,
             ) {
                 self.$member.emit(sender, msg)
@@ -1296,27 +1295,27 @@ macro_rules! impl_widget_ext_via {
                 self.$member.set_tooltip(txt)
             }
 
-            fn color(&self) -> Color {
+            fn color(&self) -> $crate::enums::Color {
                 self.$member.color()
             }
 
-            fn set_color(&mut self, color: Color) {
+            fn set_color(&mut self, color: $crate::enums::Color) {
                 self.$member.set_color(color)
             }
 
-            fn label_color(&self) -> Color {
+            fn label_color(&self) -> $crate::enums::Color {
                 self.$member.label_color()
             }
 
-            fn set_label_color(&mut self, color: Color) {
+            fn set_label_color(&mut self, color: $crate::enums::Color) {
                 self.$member.set_label_color(color)
             }
 
-            fn label_font(&self) -> Font {
+            fn label_font(&self) -> $crate::enums::Font {
                 self.$member.label_font()
             }
 
-            fn set_label_font(&mut self, font: Font) {
+            fn set_label_font(&mut self, font: $crate::enums::Font) {
                 self.$member.set_label_font(font)
             }
 
@@ -1328,19 +1327,19 @@ macro_rules! impl_widget_ext_via {
                 self.$member.set_label_size(sz)
             }
 
-            fn label_type(&self) -> LabelType {
+            fn label_type(&self) -> $crate::enums::LabelType {
                 self.$member.label_type()
             }
 
-            fn set_label_type(&mut self, typ: LabelType) {
+            fn set_label_type(&mut self, typ: $crate::enums::LabelType) {
                 self.$member.set_label_type(typ)
             }
 
-            fn frame(&self) -> FrameType {
+            fn frame(&self) -> $crate::enums::FrameType {
                 self.$member.frame()
             }
 
-            fn set_frame(&mut self, typ: FrameType) {
+            fn set_frame(&mut self, typ: $crate::enums::FrameType) {
                 self.$member.set_frame(typ)
             }
 
@@ -1356,23 +1355,23 @@ macro_rules! impl_widget_ext_via {
                 self.$member.clear_changed()
             }
 
-            fn align(&self) -> Align {
+            fn align(&self) -> $crate::enums::Align {
                 self.$member.align()
             }
 
-            fn set_align(&mut self, align: Align) {
+            fn set_align(&mut self, align: $crate::enums::Align) {
                 self.$member.set_align(align)
             }
 
-            fn parent(&self) -> Option<crate::group::Group> {
+            fn parent(&self) -> Option<$crate::group::Group> {
                 self.$member.parent()
             }
 
-            fn selection_color(&mut self) -> Color {
+            fn selection_color(&mut self) -> $crate::enums::Color {
                 self.$member.selection_color()
             }
 
-            fn set_selection_color(&mut self, color: Color) {
+            fn set_selection_color(&mut self, color: $crate::enums::Color) {
                 self.$member.set_selection_color(color)
             }
 
@@ -1428,11 +1427,11 @@ macro_rules! impl_widget_ext_via {
                 self.$member.set_damage(flag)
             }
 
-            fn damage_type(&self) -> Damage {
+            fn damage_type(&self) -> $crate::enums::Damage {
                 self.$member.damage_type()
             }
 
-            fn set_damage_type(&mut self, mask: Damage) {
+            fn set_damage_type(&mut self, mask: $crate::enums::Damage) {
                 self.$member.set_damage_type(mask)
             }
 
@@ -1440,11 +1439,11 @@ macro_rules! impl_widget_ext_via {
                 self.$member.clear_damage()
             }
 
-            fn set_trigger(&mut self, trigger: CallbackTrigger) {
+            fn set_trigger(&mut self, trigger: $crate::enums::CallbackTrigger) {
                 self.$member.set_trigger(trigger)
             }
 
-            fn trigger(&self) -> CallbackTrigger {
+            fn trigger(&self) -> $crate::enums::CallbackTrigger {
                 self.$member.trigger()
             }
 
@@ -1452,7 +1451,7 @@ macro_rules! impl_widget_ext_via {
                 self.$member.as_window()
             }
 
-            fn as_group(&self) -> Option<crate::group::Group> {
+            fn as_group(&self) -> Option<$crate::group::Group> {
                 self.$member.as_group()
             }
 
@@ -1500,7 +1499,7 @@ macro_rules! impl_widget_ext_via {
                 self.$member.widget_resize(x, y, w, h)
             }
 
-            fn handle_event(&mut self, event: Event) {
+            fn handle_event(&mut self, event: $crate::enums::Event) {
                 self.$member.handle_event(event)
             }
         }
@@ -1510,7 +1509,7 @@ macro_rules! impl_widget_ext_via {
 #[macro_export]
 /// Implements WidgetBase via a member
 macro_rules! impl_widget_base_via {
-    ($widget:ty, $base:ty, $member:tt) => {        
+    ($widget:ty, $base:ty, $member:tt) => {
         unsafe impl WidgetBase for $widget {
             fn new<T: Into<Option<&'static str>>>(
                 x: i32,
@@ -1527,14 +1526,16 @@ macro_rules! impl_widget_base_via {
             }
 
             fn default_fill() -> Self {
-                Self::new(0, 0, 0, 0, None).size_of_parent().center_of_parent()
+                Self::new(0, 0, 0, 0, None)
+                    .size_of_parent()
+                    .center_of_parent()
             }
 
             fn delete(wid: Self) {
                 <$base>::delete(wid.$member)
             }
 
-            unsafe fn from_widget_ptr(ptr: crate::app::WidgetPtr) -> Self {
+            unsafe fn from_widget_ptr(ptr: $crate::app::WidgetPtr) -> Self {
                 let $member = <$base>::from_widget_ptr(ptr);
                 Self {
                     $member,
@@ -1550,7 +1551,10 @@ macro_rules! impl_widget_base_via {
                 }
             }
 
-            fn handle<F: FnMut(&mut Self, Event) -> bool + 'static>(&mut self, mut cb: F) {
+            fn handle<F: FnMut(&mut Self, $crate::enums::Event) -> bool + 'static>(
+                &mut self,
+                mut cb: F,
+            ) {
                 let mut widget = self.clone();
                 self.$member.handle(move |_, ev| cb(&mut widget, ev));
             }
@@ -1564,17 +1568,23 @@ macro_rules! impl_widget_base_via {
                 self.$member.draw_data()
             }
 
-            unsafe fn handle_data(&mut self) -> Option<Box<dyn FnMut(Event) -> bool>> {
+            unsafe fn handle_data(
+                &mut self,
+            ) -> Option<Box<dyn FnMut($crate::enums::Event) -> bool>> {
                 self.$member.handle_data()
             }
 
-            fn resize_callback<F: FnMut(&mut Self, i32, i32, i32, i32) + 'static>(&mut self, mut cb: F) {
+            fn resize_callback<F: FnMut(&mut Self, i32, i32, i32, i32) + 'static>(
+                &mut self,
+                mut cb: F,
+            ) {
                 let mut widget = self.clone();
-                self.$member.resize_callback(move |_, x, y, w, h| cb(&mut widget, x, y, w, h))
+                self.$member
+                    .resize_callback(move |_, x, y, w, h| cb(&mut widget, x, y, w, h))
             }
         }
     };
 }
 
-pub use impl_widget_ext_via;
 pub use impl_widget_base_via;
+pub use impl_widget_ext_via;

--- a/fltk/src/macros/window.rs
+++ b/fltk/src/macros/window.rs
@@ -9,7 +9,7 @@ macro_rules! impl_window_ext {
                 {
                     return RawWindowHandle::Windows(windows::WindowsHandle {
                         hwnd: self.raw_handle(),
-                        hinstance: crate::app::display(),
+                        hinstance: $crate::app::display(),
                         ..windows::WindowsHandle::empty()
                     });
                 }
@@ -46,7 +46,7 @@ macro_rules! impl_window_ext {
                 {
                     return RawWindowHandle::Xlib(unix::XlibHandle {
                         window: self.raw_handle(),
-                        display: crate::app::display(),
+                        display: $crate::app::display(),
                         ..unix::XlibHandle::empty()
                     });
                 }
@@ -54,7 +54,7 @@ macro_rules! impl_window_ext {
                 // {
                 //     let mut handle = Win32Handle::empty();
                 //     handle.hwnd = self.raw_handle();
-                //     handle.hinstance = crate::app::display();
+                //     handle.hinstance = $crate::app::display();
                 //     return RawWindowHandle::Win32(handle);
                 // }
 
@@ -88,7 +88,7 @@ macro_rules! impl_window_ext {
                 // {
                 //     let mut handle = XlibHandle::empty();
                 //     handle.window = self.raw_handle();
-                //     handle.display = crate::app::display();
+                //     handle.display = $crate::app::display();
                 //     return RawWindowHandle::Xlib(handle);
                 // }
             }
@@ -137,7 +137,7 @@ macro_rules! impl_window_ext {
                             None
                         } else {
                             let img =
-                                Image::from_image_ptr(image_ptr as *mut fltk_sys::image::Fl_Image);
+                            $crate::image::Image::from_image_ptr(image_ptr as *mut fltk_sys::image::Fl_Image);
                             Some(Box::new(img))
                         }
                     }
@@ -147,40 +147,40 @@ macro_rules! impl_window_ext {
                     assert!(!self.was_deleted());
                     assert!(
                         std::any::type_name::<T>()
-                            != std::any::type_name::<crate::image::SharedImage>(),
+                            != std::any::type_name::<$crate::image::SharedImage>(),
                         "SharedImage icons are not supported!"
                     );
                     assert!(
-                        std::any::type_name::<T>() != std::any::type_name::<crate::image::Pixmap>(),
+                        std::any::type_name::<T>() != std::any::type_name::<$crate::image::Pixmap>(),
                         "Pixmap icons are not supported!"
                     );
                     assert!(
-                        std::any::type_name::<T>() != std::any::type_name::<crate::image::XpmImage>(),
+                        std::any::type_name::<T>() != std::any::type_name::<$crate::image::XpmImage>(),
                         "Xpm icons are not supported!"
                     );
                     assert!(
-                        std::any::type_name::<T>() != std::any::type_name::<crate::image::XbmImage>(),
+                        std::any::type_name::<T>() != std::any::type_name::<$crate::image::XbmImage>(),
                         "Xbm icons are not supported!"
                     );
                     assert!(
-                        std::any::type_name::<T>() != std::any::type_name::<crate::image::PnmImage>(),
+                        std::any::type_name::<T>() != std::any::type_name::<$crate::image::PnmImage>(),
                         "Pnm icons are not supported!"
                     );
                     assert!(
-                        std::any::type_name::<T>() != std::any::type_name::<crate::image::GifImage>(),
+                        std::any::type_name::<T>() != std::any::type_name::<$crate::image::GifImage>(),
                         "Gif icons are not supported!"
                     );
                     assert!(
-                        std::any::type_name::<T>() != std::any::type_name::<crate::image::Image>(),
+                        std::any::type_name::<T>() != std::any::type_name::<$crate::image::Image>(),
                         "Icon images can't be generic!"
                     );
                     assert!(
-                        std::any::type_name::<T>() != std::any::type_name::<crate::image::TiledImage>(),
+                        std::any::type_name::<T>() != std::any::type_name::<$crate::image::TiledImage>(),
                         "TiledImage icons are not supported!"
                     );
                     if let Some(mut image) = image {
                         assert!(!image.was_deleted());
-                        if std::any::type_name::<T>() == std::any::type_name::<crate::image::SvgImage>()
+                        if std::any::type_name::<T>() == std::any::type_name::<$crate::image::SvgImage>()
                         {
                             unsafe {
                                 image.increment_arc();
@@ -282,7 +282,7 @@ macro_rules! impl_window_ext {
                     Fl_Window_set_raw_handle(self.inner as *mut Fl_Window, mem::transmute(&handle));
                 }
 
-                fn region(&self) -> crate::draw::Region {
+                fn region(&self) -> $crate::draw::Region {
                     assert!(!self.was_deleted());
                     unsafe {
                         let ptr = [<$flname _region>](self.inner);
@@ -291,7 +291,7 @@ macro_rules! impl_window_ext {
                     }
                 }
 
-                unsafe fn set_region(&mut self, region: crate::draw::Region) {
+                unsafe fn set_region(&mut self, region: $crate::draw::Region) {
                     assert!(!self.was_deleted());
                     assert!(!region.is_null());
                     [<$flname _set_region>](self.inner, region)
@@ -336,39 +336,39 @@ macro_rules! impl_window_ext {
                     assert!(self.h() != 0);
                     assert!(
                         std::any::type_name::<I>()
-                            != std::any::type_name::<crate::image::SharedImage>(),
+                            != std::any::type_name::<$crate::image::SharedImage>(),
                         "SharedImage is not supported!"
                     );
                     assert!(
-                        std::any::type_name::<I>() != std::any::type_name::<crate::image::XbmImage>(),
+                        std::any::type_name::<I>() != std::any::type_name::<$crate::image::XbmImage>(),
                         "Xbm is not supported!"
                     );
                     assert!(
-                        std::any::type_name::<I>() != std::any::type_name::<crate::image::PnmImage>(),
+                        std::any::type_name::<I>() != std::any::type_name::<$crate::image::PnmImage>(),
                         "Pnm is not supported!"
                     );
                     assert!(
-                        std::any::type_name::<I>() != std::any::type_name::<crate::image::GifImage>(),
+                        std::any::type_name::<I>() != std::any::type_name::<$crate::image::GifImage>(),
                         "Gif is not supported!"
                     );
                     assert!(
-                        std::any::type_name::<I>() != std::any::type_name::<crate::image::JpegImage>(),
+                        std::any::type_name::<I>() != std::any::type_name::<$crate::image::JpegImage>(),
                         "Jpeg is not supported!"
                     );
                     assert!(
-                        std::any::type_name::<I>() != std::any::type_name::<crate::image::SvgImage>(),
+                        std::any::type_name::<I>() != std::any::type_name::<$crate::image::SvgImage>(),
                         "Svg is not supported!"
                     );
                     assert!(
-                        std::any::type_name::<I>() != std::any::type_name::<crate::image::PngImage>(),
+                        std::any::type_name::<I>() != std::any::type_name::<$crate::image::PngImage>(),
                         "Png is not supported!"
                     );
                     assert!(
-                        std::any::type_name::<I>() != std::any::type_name::<crate::image::Image>(),
+                        std::any::type_name::<I>() != std::any::type_name::<$crate::image::Image>(),
                         "Images can't be generic!"
                     );
                     assert!(
-                        std::any::type_name::<I>() != std::any::type_name::<crate::image::TiledImage>(),
+                        std::any::type_name::<I>() != std::any::type_name::<$crate::image::TiledImage>(),
                         "TiledImage is not supported!"
                     );
                     unsafe {
@@ -389,7 +389,7 @@ macro_rules! impl_window_ext {
                             None
                         } else {
                             let img =
-                                Image::from_image_ptr(image_ptr as *mut fltk_sys::image::Fl_Image);
+                            $crate::image::Image::from_image_ptr(image_ptr as *mut fltk_sys::image::Fl_Image);
                             Some(Box::new(img))
                         }
                     }
@@ -407,7 +407,7 @@ macro_rules! impl_window_ext {
 
                 fn set_cursor_image(
                     &mut self,
-                    mut image: crate::image::RgbImage,
+                    mut image: $crate::image::RgbImage,
                     hot_x: i32,
                     hot_y: i32,
                 ) {

--- a/fltk/src/macros/window.rs
+++ b/fltk/src/macros/window.rs
@@ -1,3 +1,4 @@
+#[doc(hidden)]
 #[macro_export]
 /// Implements WindowExt
 macro_rules! impl_window_ext {

--- a/fltk/src/macros/window.rs
+++ b/fltk/src/macros/window.rs
@@ -19,9 +19,9 @@ macro_rules! impl_window_ext {
                 {
                     let raw = self.raw_handle();
                     extern "C" {
-                        pub fn my_getContentView(xid: *mut raw::c_void) -> *mut raw::c_void;
+                        pub fn cfltk_getContentView(xid: *mut raw::c_void) -> *mut raw::c_void;
                     }
-                    let cv = unsafe { my_getContentView(raw) };
+                    let cv = unsafe { cfltk_getContentView(raw) };
                     return RawWindowHandle::MacOS(macos::MacOSHandle {
                         ns_window: raw,
                         ns_view: cv as _,
@@ -63,9 +63,9 @@ macro_rules! impl_window_ext {
                 // {
                 //     let raw = self.raw_handle();
                 //     extern "C" {
-                //         pub fn my_getContentView(xid: *mut raw::c_void) -> *mut raw::c_void;
+                //         pub fn cfltk_getContentView(xid: *mut raw::c_void) -> *mut raw::c_void;
                 //     }
-                //     let cv = unsafe { my_getContentView(raw) };
+                //     let cv = unsafe { cfltk_getContentView(raw) };
                 //     let mut handle = AppKitHandle::empty();
                 //     handle.ns_window = raw;
                 //     handle.ns_view = cv as _;

--- a/fltk/src/menu.rs
+++ b/fltk/src/menu.rs
@@ -1,10 +1,6 @@
-use crate::enums::{
-    Align, CallbackTrigger, Color, Damage, Event, Font, FrameType, LabelType, Shortcut,
-};
-use crate::image::Image;
+use crate::enums::{Color, Font, LabelType};
 use crate::prelude::*;
 use crate::utils::FlString;
-use crate::window::Window;
 use fltk_sys::menu::*;
 use std::{
     ffi::{CStr, CString},

--- a/fltk/src/menu.rs
+++ b/fltk/src/menu.rs
@@ -543,7 +543,7 @@ pub fn mac_set_about<F: FnMut() + 'static>(cb: F) {
         unsafe extern "C" fn shim(_wid: *mut fltk_sys::menu::Fl_Widget, data: *mut raw::c_void) {
             let a: *mut Box<dyn FnMut()> = data as *mut Box<dyn FnMut()>;
             let f: &mut (dyn FnMut()) = &mut **a;
-            let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| f()));
+            let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(f));
         }
         let a: *mut Box<dyn FnMut()> = Box::into_raw(Box::new(Box::new(cb)));
         let data: *mut raw::c_void = a as *mut std::ffi::c_void;

--- a/fltk/src/misc.rs
+++ b/fltk/src/misc.rs
@@ -1,9 +1,8 @@
-use crate::enums::{Align, CallbackTrigger, Color, Damage, Event, Font, FrameType, LabelType};
-use crate::image::Image;
+use crate::enums::{Color, Font, FrameType};
 use crate::prelude::*;
 use crate::utils::FlString;
-use crate::window::Window;
 use crate::widget::Widget;
+use crate::window::Window;
 use fltk_sys::misc::*;
 use std::{
     ffi::{CStr, CString},

--- a/fltk/src/output.rs
+++ b/fltk/src/output.rs
@@ -1,14 +1,7 @@
-use crate::enums::{Align, CallbackTrigger, Color, Damage, Event, Font, FrameType, LabelType};
-use crate::image::Image;
 use crate::prelude::*;
 use crate::utils::FlString;
-use crate::window::Window;
 use fltk_sys::input::*;
-use std::{
-    ffi::{CStr, CString},
-    mem,
-    os::raw,
-};
+use std::ffi::{CStr, CString};
 
 /// Sets the input widget's type
 #[repr(i32)]

--- a/fltk/src/prelude.rs
+++ b/fltk/src/prelude.rs
@@ -20,6 +20,8 @@ pub enum FltkError {
     Internal(FltkErrorKind),
     /// Error using an errorneous env variable
     EnvVarError(std::env::VarError),
+    /// Parsing error
+    ParseIntError(std::num::ParseIntError),
     /// Unknown error
     Unknown(String),
 }
@@ -47,6 +49,8 @@ pub enum FltkErrorKind {
     TableError,
     /// Error due to printing
     PrintError,
+    /// Invalid color
+    InvalidColor,
 }
 
 impl std::error::Error for FltkError {
@@ -67,6 +71,7 @@ impl fmt::Display for FltkError {
             FltkError::Internal(ref err) => write!(f, "An internal error occured {:?}", err),
             FltkError::EnvVarError(ref err) => write!(f, "An env var error occured {:?}", err),
             FltkError::Utf8Error(ref err) => write!(f, "A UTF8 conversion error occured {:?}", err),
+            FltkError::ParseIntError(ref err) => write!(f, "An int parsing error occured {:?}", err),
             FltkError::Unknown(ref err) => write!(f, "An unknown error occurred {:?}", err),
         }
     }
@@ -93,6 +98,12 @@ impl From<std::env::VarError> for FltkError {
 impl From<std::string::FromUtf8Error> for FltkError {
     fn from(err: std::string::FromUtf8Error) -> FltkError {
         FltkError::Utf8Error(err)
+    }
+}
+
+impl From<std::num::ParseIntError> for FltkError {
+    fn from(err: std::num::ParseIntError) -> FltkError {
+        FltkError::ParseIntError(err)
     }
 }
 

--- a/fltk/src/prelude.rs
+++ b/fltk/src/prelude.rs
@@ -118,6 +118,10 @@ pub trait WidgetType {
 /// Defines the methods implemented by all widgets
 /// # Safety
 /// fltk-rs traits depend on some FLTK internal code
+/// # Warning
+/// fltk-rs traits are non-exhaustive,
+/// to avoid future breakage if you try to implement them manually,
+/// use the Deref and DerefMut pattern or the `widget_extends!` macro
 pub unsafe trait WidgetExt {
     /// Initialize to a position x, y
     fn with_pos(self, x: i32, y: i32) -> Self
@@ -423,6 +427,10 @@ pub unsafe trait WidgetExt {
 /// Defines the extended methods implemented by all widgets
 /// # Safety
 /// fltk-rs traits depend on some FLTK internal code
+/// # Warning
+/// fltk-rs traits are non-exhaustive,
+/// to avoid future breakage if you try to implement them manually,
+/// use the Deref and DerefMut pattern or the `widget_extends!` macro
 pub unsafe trait WidgetBase: WidgetExt {
     /// Creates a new widget, takes an x, y coordinates, as well as a width and height, plus a title
     /// # Arguments
@@ -482,6 +490,10 @@ pub unsafe trait WidgetBase: WidgetExt {
 /// Defines the methods implemented by all button widgets
 /// # Safety
 /// fltk-rs traits depend on some FLTK internal code
+/// # Warning
+/// fltk-rs traits are non-exhaustive,
+/// to avoid future breakage if you try to implement them manually,
+/// use the Deref and DerefMut pattern or the `widget_extends!` macro
 pub unsafe trait ButtonExt: WidgetExt {
     /// Gets the shortcut associated with a button
     fn shortcut(&self) -> Shortcut;
@@ -539,6 +551,10 @@ pub unsafe trait ButtonExt: WidgetExt {
 /// ```
 /// # Safety
 /// fltk-rs traits depend on some FLTK internal code
+/// # Warning
+/// fltk-rs traits are non-exhaustive,
+/// to avoid future breakage if you try to implement them manually,
+/// use the Deref and DerefMut pattern or the `widget_extends!` macro
 pub unsafe trait GroupExt: WidgetExt {
     /// Begins a group, used for widgets implementing the group trait
     fn begin(&self);
@@ -616,6 +632,10 @@ pub unsafe trait GroupExt: WidgetExt {
 /// Defines the methods implemented by all window widgets
 /// # Safety
 /// fltk-rs traits depend on some FLTK internal code
+/// # Warning
+/// fltk-rs traits are non-exhaustive,
+/// to avoid future breakage if you try to implement them manually,
+/// use the Deref and DerefMut pattern or the `widget_extends!` macro
 pub unsafe trait WindowExt: GroupExt {
     /// Positions the window to the center of the screen
     fn center_screen(self) -> Self
@@ -704,6 +724,10 @@ pub unsafe trait WindowExt: GroupExt {
 /// Defines the methods implemented by all input and output widgets
 /// # Safety
 /// fltk-rs traits depend on some FLTK internal code
+/// # Warning
+/// fltk-rs traits are non-exhaustive,
+/// to avoid future breakage if you try to implement them manually,
+/// use the Deref and DerefMut pattern or the `widget_extends!` macro
 pub unsafe trait InputExt: WidgetExt {
     /// Returns the value inside the input/output widget
     fn value(&self) -> String;
@@ -774,6 +798,10 @@ pub unsafe trait InputExt: WidgetExt {
 /// Defines the methods implemented by all menu widgets
 /// # Safety
 /// fltk-rs traits depend on some FLTK internal code
+/// # Warning
+/// fltk-rs traits are non-exhaustive,
+/// to avoid future breakage if you try to implement them manually,
+/// use the Deref and DerefMut pattern or the `widget_extends!` macro
 pub unsafe trait MenuExt: WidgetExt {
     /// Get a menu item by name
     fn find_item(&self, name: &str) -> Option<crate::menu::MenuItem>;
@@ -905,6 +933,10 @@ pub unsafe trait MenuExt: WidgetExt {
 /// Defines the methods implemented by all valuator widgets
 /// # Safety
 /// fltk-rs traits depend on some FLTK internal code
+/// # Warning
+/// fltk-rs traits are non-exhaustive,
+/// to avoid future breakage if you try to implement them manually,
+/// use the Deref and DerefMut pattern or the `widget_extends!` macro
 pub unsafe trait ValuatorExt: WidgetExt {
     /// Set bounds of a valuator
     fn set_bounds(&mut self, a: f64, b: f64);
@@ -944,6 +976,10 @@ pub unsafe trait ValuatorExt: WidgetExt {
 /// Defines the methods implemented by `TextDisplay` and `TextEditor`
 /// # Safety
 /// fltk-rs traits depend on some FLTK internal code
+/// # Warning
+/// fltk-rs traits are non-exhaustive,
+/// to avoid future breakage if you try to implement them manually,
+/// use the Deref and DerefMut pattern or the `widget_extends!` macro
 pub unsafe trait DisplayExt: WidgetExt {
     /// Get the associated `TextBuffer`
     fn buffer(&self) -> Option<crate::text::TextBuffer>;
@@ -1079,6 +1115,10 @@ pub unsafe trait DisplayExt: WidgetExt {
 /// Defines the methods implemented by all browser types
 /// # Safety
 /// fltk-rs traits depend on some FLTK internal code
+/// # Warning
+/// fltk-rs traits are non-exhaustive,
+/// to avoid future breakage if you try to implement them manually,
+/// use the Deref and DerefMut pattern or the `widget_extends!` macro
 pub unsafe trait BrowserExt: WidgetExt {
     /// Removes the specified line.
     /// Lines start at 1
@@ -1188,6 +1228,10 @@ pub unsafe trait BrowserExt: WidgetExt {
 /// Defines the methods implemented by table types
 /// # Safety
 /// fltk-rs traits depend on some FLTK internal code
+/// # Warning
+/// fltk-rs traits are non-exhaustive,
+/// to avoid future breakage if you try to implement them manually,
+/// use the Deref and DerefMut pattern or the `widget_extends!` macro
 pub unsafe trait TableExt: GroupExt {
     /// Clears the table
     fn clear(&mut self);
@@ -1331,6 +1375,10 @@ pub unsafe trait TableExt: GroupExt {
 /// Defines the methods implemented by all image types
 /// # Safety
 /// fltk-rs traits depend on some FLTK internal code
+/// # Warning
+/// fltk-rs traits are non-exhaustive,
+/// to avoid future breakage if you try to implement them manually,
+/// use the Deref and DerefMut pattern
 pub unsafe trait ImageExt {
     /// Performs a deep copy of the image
     fn copy(&self) -> Self

--- a/fltk/src/table.rs
+++ b/fltk/src/table.rs
@@ -1,15 +1,7 @@
-use crate::enums::{Align, CallbackTrigger, Color, Damage, Event, Font, FrameType, LabelType};
-use crate::image::Image;
 use crate::prelude::*;
 use crate::utils::FlString;
-use crate::window::Window;
-use crate::widget::Widget;
 use fltk_sys::table::*;
-use std::{
-    ffi::{CStr, CString},
-    mem,
-    os::raw,
-};
+use std::ffi::{CStr, CString};
 
 /// Creates a table
 /// For a simpler boilerplate-less table, check the [fltk-table crate](https://crates.io/crates/fltk-table)

--- a/fltk/src/text.rs
+++ b/fltk/src/text.rs
@@ -1,12 +1,9 @@
-use crate::enums::{Align, CallbackTrigger, Color, Damage, Event, Font, FrameType, Key, LabelType};
-use crate::image::Image;
+use crate::enums::{Color, Font, Key};
 use crate::prelude::*;
 use crate::utils::FlString;
-use crate::window::Window;
 use fltk_sys::text::*;
 use std::{
     ffi::{CStr, CString},
-    mem,
     os::raw,
     sync::atomic::{AtomicUsize, Ordering},
 };

--- a/fltk/src/tree.rs
+++ b/fltk/src/tree.rs
@@ -1336,7 +1336,7 @@ impl TreeItem {
         unsafe { Fl_Tree_Item_label_w(self.inner) }
     }
 
-    /// Sets the label's width
+    /// Gets the label's height
     pub fn label_h(&self) -> i32 {
         assert!(!self.was_deleted());
         unsafe { Fl_Tree_Item_label_h(self.inner) }

--- a/fltk/src/tree.rs
+++ b/fltk/src/tree.rs
@@ -1,8 +1,7 @@
-use crate::enums::{Align, CallbackTrigger, Color, Damage, Event, Font, FrameType, Key, LabelType};
+use crate::enums::{Color, Font, FrameType, Key};
 use crate::image::Image;
 use crate::prelude::*;
 use crate::utils::FlString;
-use crate::window::Window;
 use crate::widget::Widget;
 use fltk_sys::tree::*;
 use std::{
@@ -1158,7 +1157,7 @@ impl Tree {
         unsafe {
             let ret = Fl_Tree_item_pathname(self.inner, temp.as_mut_ptr() as _, 256, item.inner);
             if ret == 0 {
-                if let Some(pos) =  temp.iter().position(|x| *x == 0) {
+                if let Some(pos) = temp.iter().position(|x| *x == 0) {
                     temp = temp.split_at(pos).0.to_vec();
                 }
                 Ok(String::from_utf8_lossy(&temp).to_string())
@@ -1410,14 +1409,14 @@ impl TreeItem {
         unsafe { mem::transmute(Fl_Tree_Item_labelfgcolor(self.inner)) }
     }
 
-    #[deprecated(since="1.2.19", note="please use `set_label_fgcolor` instead")]
+    #[deprecated(since = "1.2.19", note = "please use `set_label_fgcolor` instead")]
     /// Sets the label's foreground color
     pub fn set_label_fg_color(&mut self, val: Color) {
         assert!(!self.was_deleted());
         unsafe { Fl_Tree_Item_set_labelfgcolor(self.inner, val.bits() as u32) }
     }
 
-    #[deprecated(since="1.2.19", note="please use `label_fgcolor` instead")]
+    #[deprecated(since = "1.2.19", note = "please use `label_fgcolor` instead")]
     /// Gets the label's foreground color
     pub fn label_fg_color(&self) -> Color {
         assert!(!self.was_deleted());
@@ -1455,7 +1454,7 @@ impl TreeItem {
         unsafe { Fl_Tree_Item_set_widget(self.inner, val.as_widget_ptr() as *mut Fl_Widget) }
     }
 
-    #[deprecated(since="1.2.18", note="please use `try_widget` instead")]
+    #[deprecated(since = "1.2.18", note = "please use `try_widget` instead")]
     /// Gets the item's associated widget
     pub fn widget(&self) -> Widget {
         assert!(!self.was_deleted());

--- a/fltk/src/utils.rs
+++ b/fltk/src/utils.rs
@@ -123,7 +123,7 @@ pub fn char_len(c: char) -> usize {
 /// Get a window's content view
 pub fn content_view<W: crate::prelude::WindowExt>(w: &W) -> *const raw::c_void {
     extern "C" {
-        pub fn my_getContentView(xid: *mut raw::c_void) -> *mut raw::c_void;
+        pub fn cfltk_getContentView(xid: *mut raw::c_void) -> *mut raw::c_void;
     }
-    unsafe { my_getContentView(w.raw_handle() as _) as _ }
+    unsafe { cfltk_getContentView(w.raw_handle() as _) as _ }
 }

--- a/fltk/src/valuator.rs
+++ b/fltk/src/valuator.rs
@@ -1,8 +1,6 @@
-use crate::enums::{Align, CallbackTrigger, Color, Damage, Event, Font, FrameType, LabelType};
-use crate::image::Image;
+use crate::enums::{Color, Font, FrameType};
 use crate::prelude::*;
 use crate::utils::FlString;
-use crate::window::Window;
 use fltk_sys::valuator::*;
 use std::{
     ffi::{CStr, CString},

--- a/fltk/src/widget.rs
+++ b/fltk/src/widget.rs
@@ -1,12 +1,7 @@
-use crate::enums::{Align, CallbackTrigger, Color, Damage, Event, Font, FrameType, LabelType};
-use crate::image::Image;
 use crate::prelude::*;
 use crate::utils::FlString;
-use crate::window::Window;
 use fltk_sys::widget::*;
 use std::ffi::{CStr, CString};
-use std::mem;
-use std::os::raw;
 
 /// An abstract type, shouldn't be instantiated in user code
 #[derive(Debug)]

--- a/fltk/src/window.rs
+++ b/fltk/src/window.rs
@@ -213,6 +213,48 @@ impl SingleWindow {
     pub fn pixel_h(&self) -> i32 {
         (self.pixels_per_unit() * self.h() as f32) as i32
     }
+
+    /// Get the default XA_WM_CLASS property for all windows of your application
+    pub fn default_xclass() -> Option<String> {
+        unsafe {
+            let ptr = Fl_Window_default_xclass();
+            if ptr.is_null() {
+                None
+            } else {
+                Some(CStr::from_ptr(ptr).to_string_lossy().to_string())
+            }
+        }
+    }
+
+    /// Set the default XA_WM_CLASS property for all windows of your application
+    pub fn set_default_xclass(s: &str) {
+        let s = CString::safe_new(s);
+        unsafe {
+            Fl_Window_set_default_xclass(s.as_ptr())
+        }
+    }
+    
+    /// Get the window's XA_WM_CLASS property
+    pub fn xclass(&self) -> Option<String> {
+        assert!(!self.was_deleted());
+        unsafe {
+            let ptr = Fl_Window_xclass(self.inner as _);
+            if ptr.is_null() {
+                None
+            } else {
+                Some(CStr::from_ptr(ptr).to_string_lossy().to_string())
+            }
+        }
+    }
+
+    /// Set the window's XA_WM_CLASS property
+    pub fn set_xclass(&mut self, s: &str) {
+        assert!(!self.was_deleted());
+        let s = CString::safe_new(s);
+        unsafe {
+            Fl_Window_set_xclass(self.inner as _, s.as_ptr())
+        }
+    }
 }
 
 /// Creates a double (buffered) window widget
@@ -435,6 +477,48 @@ impl DoubleWindow {
                 XUnmapWindow(crate::app::display() as _, self.raw_handle());
                 crate::app::flush();
             }
+        }
+    }
+
+    /// Get the default XA_WM_CLASS property for all windows of your application
+    pub fn default_xclass() -> Option<String> {
+        unsafe {
+            let ptr = Fl_Window_default_xclass();
+            if ptr.is_null() {
+                None
+            } else {
+                Some(CStr::from_ptr(ptr).to_string_lossy().to_string())
+            }
+        }
+    }
+
+    /// Set the default XA_WM_CLASS property for all windows of your application
+    pub fn set_default_xclass(s: &str) {
+        let s = CString::safe_new(s);
+        unsafe {
+            Fl_Window_set_default_xclass(s.as_ptr())
+        }
+    }
+    
+    /// Get the window's XA_WM_CLASS property
+    pub fn xclass(&self) -> Option<String> {
+        assert!(!self.was_deleted());
+        unsafe {
+            let ptr = Fl_Window_xclass(self.inner as _);
+            if ptr.is_null() {
+                None
+            } else {
+                Some(CStr::from_ptr(ptr).to_string_lossy().to_string())
+            }
+        }
+    }
+
+    /// Set the window's XA_WM_CLASS property
+    pub fn set_xclass(&mut self, s: &str) {
+        assert!(!self.was_deleted());
+        let s = CString::safe_new(s);
+        unsafe {
+            Fl_Window_set_xclass(self.inner as _, s.as_ptr())
         }
     }
 }

--- a/fltk/src/window.rs
+++ b/fltk/src/window.rs
@@ -230,11 +230,9 @@ impl SingleWindow {
     /// This should be called before showing with window
     pub fn set_default_xclass(s: &str) {
         let s = CString::safe_new(s);
-        unsafe {
-            Fl_Window_set_default_xclass(s.as_ptr())
-        }
+        unsafe { Fl_Window_set_default_xclass(s.as_ptr()) }
     }
-    
+
     /// Get the window's XA_WM_CLASS property
     pub fn xclass(&self) -> Option<String> {
         assert!(!self.was_deleted());
@@ -253,9 +251,7 @@ impl SingleWindow {
     pub fn set_xclass(&mut self, s: &str) {
         assert!(!self.was_deleted());
         let s = CString::safe_new(s);
-        unsafe {
-            Fl_Window_set_xclass(self.inner as _, s.as_ptr())
-        }
+        unsafe { Fl_Window_set_xclass(self.inner as _, s.as_ptr()) }
     }
 }
 
@@ -498,11 +494,9 @@ impl DoubleWindow {
     /// This should be called before showing with window
     pub fn set_default_xclass(s: &str) {
         let s = CString::safe_new(s);
-        unsafe {
-            Fl_Window_set_default_xclass(s.as_ptr())
-        }
+        unsafe { Fl_Window_set_default_xclass(s.as_ptr()) }
     }
-    
+
     /// Get the window's XA_WM_CLASS property
     pub fn xclass(&self) -> Option<String> {
         assert!(!self.was_deleted());
@@ -521,9 +515,7 @@ impl DoubleWindow {
     pub fn set_xclass(&mut self, s: &str) {
         assert!(!self.was_deleted());
         let s = CString::safe_new(s);
-        unsafe {
-            Fl_Window_set_xclass(self.inner as _, s.as_ptr())
-        }
+        unsafe { Fl_Window_set_xclass(self.inner as _, s.as_ptr()) }
     }
 }
 

--- a/fltk/src/window.rs
+++ b/fltk/src/window.rs
@@ -226,7 +226,8 @@ impl SingleWindow {
         }
     }
 
-    /// Set the default XA_WM_CLASS property for all windows of your application
+    /// Set the default XA_WM_CLASS property for all windows of your application.
+    /// This should be called before showing with window
     pub fn set_default_xclass(s: &str) {
         let s = CString::safe_new(s);
         unsafe {
@@ -247,7 +248,8 @@ impl SingleWindow {
         }
     }
 
-    /// Set the window's XA_WM_CLASS property
+    /// Set the window's XA_WM_CLASS property.
+    /// This should be called before showing the window
     pub fn set_xclass(&mut self, s: &str) {
         assert!(!self.was_deleted());
         let s = CString::safe_new(s);
@@ -492,7 +494,8 @@ impl DoubleWindow {
         }
     }
 
-    /// Set the default XA_WM_CLASS property for all windows of your application
+    /// Set the default XA_WM_CLASS property for all windows of your application.
+    /// This should be called before showing with window
     pub fn set_default_xclass(s: &str) {
         let s = CString::safe_new(s);
         unsafe {
@@ -513,7 +516,8 @@ impl DoubleWindow {
         }
     }
 
-    /// Set the window's XA_WM_CLASS property
+    /// Set the window's XA_WM_CLASS property.
+    /// This should be called before showing the window
     pub fn set_xclass(&mut self, s: &str) {
         assert!(!self.was_deleted());
         let s = CString::safe_new(s);

--- a/fltk/src/window.rs
+++ b/fltk/src/window.rs
@@ -193,11 +193,11 @@ impl SingleWindow {
         #[cfg(target_os = "macos")]
         {
             extern "C" {
-                pub fn my_getScalingFactor(handle: *mut raw::c_void) -> f64;
+                pub fn cfltk_getScalingFactor(handle: *mut raw::c_void) -> f64;
             }
             let mac_version = unsafe { fltk_sys::fl::Fl_mac_os_version() };
             if mac_version >= 100700 {
-                factor = unsafe { my_getScalingFactor(self.raw_handle()) };
+                factor = unsafe { cfltk_getScalingFactor(self.raw_handle()) };
             }
         }
         let s = crate::app::screen_scale(self.screen_num());
@@ -399,11 +399,11 @@ impl DoubleWindow {
         #[cfg(target_os = "macos")]
         {
             extern "C" {
-                pub fn my_getScalingFactor(handle: *mut raw::c_void) -> f64;
+                pub fn cfltk_getScalingFactor(handle: *mut raw::c_void) -> f64;
             }
             let mac_version = unsafe { fltk_sys::fl::Fl_mac_os_version() };
             if mac_version >= 100700 {
-                factor = unsafe { my_getScalingFactor(self.raw_handle()) };
+                factor = unsafe { cfltk_getScalingFactor(self.raw_handle()) };
             }
         }
         let s = crate::app::screen_scale(self.screen_num());
@@ -433,9 +433,9 @@ impl DoubleWindow {
             #[cfg(target_os = "macos")]
             {
                 extern "C" {
-                    fn my_winShow(xid: *mut raw::c_void);
+                    fn cfltk_winShow(xid: *mut raw::c_void);
                 }
-                my_winShow(self.raw_handle());
+                cfltk_winShow(self.raw_handle());
             }
             #[cfg(not(any(target_os = "macos", target_os = "android", target_os = "windows")))]
             {
@@ -443,7 +443,7 @@ impl DoubleWindow {
                 extern "C" {
                     fn XMapWindow(display: *mut Display, win: u64);
                 }
-                XMapWindow(crate::app::display() as _, self.raw_handle());
+                XMapWindow(crate::app::display() as _, self.raw_handle() as _);
                 crate::app::flush();
             }
         }
@@ -462,9 +462,9 @@ impl DoubleWindow {
             #[cfg(target_os = "macos")]
             {
                 extern "C" {
-                    fn my_winHide(xid: *mut raw::c_void);
+                    fn cfltk_winHide(xid: *mut raw::c_void);
                 }
-                my_winHide(self.raw_handle());
+                cfltk_winHide(self.raw_handle());
             }
             #[cfg(not(any(target_os = "macos", target_os = "android", target_os = "windows")))]
             {
@@ -472,7 +472,7 @@ impl DoubleWindow {
                 extern "C" {
                     fn XUnmapWindow(display: *mut Display, win: u64);
                 }
-                XUnmapWindow(crate::app::display() as _, self.raw_handle());
+                XUnmapWindow(crate::app::display() as _, self.raw_handle() as _);
                 crate::app::flush();
             }
         }


### PR DESCRIPTION
- Cleanup macros and surrounding api. Thanks @AshfordN.
- Update doc comment on draw::set_line_style().
- Add Window xclass and default_xclass setter and getter. (Changes the XA_WM_CLASS property of the window)
- Add `Color::from_hex_str(&str)` and `to_hex_str()`.
- Optimize Color::from_rgba_tuple().
- Add draw::text_extents().
- Properly `cfltk_` prefix extern Cocoa wrapper functions.
- Fix build on 32-bit X11 systems (introduced in 1.2.11 by Window::platform_hide() and platform_show()).