### PR TITLE
Add doc comments

### DIFF
--- a/fltk/src/lib.rs
+++ b/fltk/src/lib.rs
@@ -330,10 +330,8 @@ pub mod utils;
 /// Valuator widgets
 pub mod valuator;
 
-/// Basic empty widget
 pub mod widget;
 
-/// Window widgets
 pub mod window;
 
 /// Printing related functions

--- a/fltk/src/menu.rs
+++ b/fltk/src/menu.rs
@@ -74,6 +74,36 @@ impl MenuButton {
 }
 
 /// Creates a menu choice
+///
+/// The [`set_frame`](crate::prelude::WidgetExt::set_frame) method styles the
+/// dropdown menu. `Choice` does not expose it's uderlying widget (a
+/// [`DownBox`](crate::enums::FrameType::DownBox)). It can only be changed
+/// via the app scheme or by globally changin the draw function of
+/// [`DownBox`](crate::enums::FrameType::DownBox):
+///
+/// ```rust
+///use fltk::{enums::*, prelude::*, *};
+///
+///fn my_down_box(x: i32, y: i32, w: i32, h: i32, col: Color) {
+///    draw::draw_rect_fill(x, y, w, h, Color::Red);
+///    draw::draw_rect_fill(x + 1, y + 1, w - 2, h - 2, Color::BackGround2); // change values to change thickness
+///}
+///
+///fn main() {
+///     let a = app::App::default();
+///     app::set_frame_type_cb(FrameType::DownBox, my_down_box, 0, 0, 0, 0);
+///     let mut win = window::Window::new(100, 100, 400, 300, None);
+///     win.set_color(Color::from_rgb(211, 211, 211));
+///     let mut inp = input::Input::new(50, 10, 100, 30, None); // would work for any widget which has a DownBox frame type
+///     let mut choice = menu::Choice::new(50, 100, 100, 30, None);
+///     choice.add_choice("Choice 1| Choice 2| choice 3");
+///     win.end();
+///     win.show();
+///     a.run().unwrap();
+///}
+///```
+///
+/// For more extensive options see the `custom_choice` example.
 #[derive(Debug)]
 pub struct Choice {
     inner: *mut Fl_Choice,

--- a/fltk/src/prelude.rs
+++ b/fltk/src/prelude.rs
@@ -116,6 +116,9 @@ pub trait WidgetType {
 }
 
 /// Defines the methods implemented by all widgets
+///
+/// For multithreaded usage, see the [`widget` module documentation's
+/// note](crate::widget)
 /// # Safety
 /// fltk-rs traits depend on some FLTK internal code
 /// # Warning

--- a/fltk/src/widget.rs
+++ b/fltk/src/widget.rs
@@ -1,3 +1,8 @@
+//! Basic empty widget
+//!
+//! **Multithreaded** applications can call widget methods from non-main
+//! threads, but will need to call [`app::awake()`](`crate::app::awake`) to make
+//! the main thread run the event loop.
 use crate::prelude::*;
 use crate::utils::FlString;
 use fltk_sys::widget::*;

--- a/fltk/src/window.rs
+++ b/fltk/src/window.rs
@@ -1,4 +1,15 @@
+//! Window widgets
+//!
+//! **Multithreaded** applications should always create/show/open/close windows
+//! from the main thread (This might or might not work on your specific target,
+//! due to fltk calling the underlying plattform's window code. If you want
+//! portability, avoid it.) If you need to trigger showing a windows from
+//! another thread, use [`messages`](crate::app::channel) to notify the main
+//! thread that the window needs showing. An alternative to that is
+//! [`awake_callback`](crate::app::awake_callback)
+
 #![allow(unused_imports)]
+
 
 use crate::app::screen_size;
 use crate::enums::{
@@ -278,6 +289,8 @@ crate::macros::window::impl_window_ext!(DoubleWindow, Fl_Double_Window);
 
 impl DoubleWindow {
     /// Creates a default initialized double window
+    ///
+    /// Note: Only call this from the main thread.
     pub fn default() -> DoubleWindow {
         let mut win = <DoubleWindow as Default>::default();
         win.free_position();


### PR DESCRIPTION
Hey,

this puts some things in comments that I learned from you over the past weeks. Let me know if you dislike anything :)

Two very unrelated questions though:

- One can't link to examples in the docs. One workaround is to create an `examples` submodule, and for each example have a `examples::example` submodule which contains some comments that can be linked to. See https://github.com/KillTheMule/nvim-rs where I did that. Would you be interested in that? One possible extension that I'd be fond of is actually putting the code into `examples::example` and have the example binary just call out to a `run` function or so. That way, one could actually look at linked example code from the docs (although I'm unsure how that interacts with "example autodiscovery" of recent rustdoc).
- Since windows should very much be handled by the main thread (at least creation and destruction, and showing and hiding), why do they implement `Send`? Wouldn't it make sense to leave that out, since it can't really be used anyways?