### PR TITLE
Removes unnecessary clone() in both calculator examples.

### DIFF
--- a/fltk/examples/calculator.rs
+++ b/fltk/examples/calculator.rs
@@ -175,8 +175,7 @@ fn main() {
     }
 
     for mut but in but_op_vec {
-        let label = but.label().clone();
-        let op = match label.as_str() {
+        let op = match but.label().as_str() {
             "+" => Ops::Add,
             "-" => Ops::Sub,
             "x" => Ops::Mul,

--- a/fltk/examples/calculator2.rs
+++ b/fltk/examples/calculator2.rs
@@ -194,8 +194,7 @@ fn main() {
     }
 
     for mut but in but_op_vec {
-        let label = but.label().clone();
-        let op = match label.as_str() {
+        let op = match but.label().as_str() {
             "+" => Ops::Add,
             "-" => Ops::Sub,
             "x" => Ops::Mul,


### PR DESCRIPTION
As a clone() action is expensive, it takes compute time, avoiding it is preferred, I would think. Both calculators have this unnecessary clone() function call of the label.
