### PR TITLE
Clarified documentation for the override functions

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,4 +1,4 @@
-# This is the list of fltk-rs's authors for copyright purposes.
+# This is the list of fltk-rs' authors for copyright purposes.
 #
 # This does not necessarily list everyone who has contributed code, since in
 # some cases, their employer may be the copyright holder.

--- a/fltk/src/prelude.rs
+++ b/fltk/src/prelude.rs
@@ -754,9 +754,9 @@ pub unsafe trait WindowExt: GroupExt {
     fn set_xclass(&mut self, s: &str);
     /// Clear the modal state of the window
     fn clear_modal_states(&mut self);
-    /// removes the window border and sets the window on top
+    /// removes the window border and sets the window on top, by settings the NOBORDER and OVERRIDE flags
     fn set_override(&mut self);
-    /// Checks whether set_override was called
+    /// Checks whether the OVERRIDE flag was set
     fn is_override(&self) -> bool;
     /// Forces the position of the window
     fn force_position(&mut self, flag: bool);


### PR DESCRIPTION
Provided a bit more context and clarity to the override functions' documentation, and corrected a grammatical error in the AUTHORS file.