### PR TITLE
deprecate app::release()

### DIFF
--- a/fltk/src/app/widget.rs
+++ b/fltk/src/app/widget.rs
@@ -28,6 +28,7 @@ pub fn set_grab<W: WindowExt>(win: Option<W>) {
     }
 }
 
+#[deprecated = "use app::set_grab(None) instead"]
 /// Unset the currently grabbed window
 pub fn release() {
     unsafe { fl::Fl_release() }


### PR DESCRIPTION
`app::release()` should be deprecated to follow the direction of fltk. See the [documentation](https://www.fltk.org/doc-1.3/classFl.html#a656023b0db49ae9b88e277ccdb27ce1b) for `Fl::release()`
