### PR TITLE
add functions to correctly handle closures used in callbacks

### DIFF
--- a/fltk/src/app/rt.rs
+++ b/fltk/src/app/rt.rs
@@ -244,6 +244,7 @@ unsafe extern "C" fn idle_shim(data: *mut raw::c_void) {
 }
 
 /// Add an idle callback to run within the event loop.
+/// This function returns a handle that can be used for future interaction with the callback.
 /// Calls to `WidgetExt::redraw` within the callback require an explicit sleep
 pub fn add_idle3<F: FnMut(IdleHandle) + 'static>(cb: F) -> IdleHandle {
     unsafe {
@@ -256,7 +257,7 @@ pub fn add_idle3<F: FnMut(IdleHandle) + 'static>(cb: F) -> IdleHandle {
     }
 }
 
-/// Remove an idle function
+/// Remove the idle function associated with the handle
 pub fn remove_idle3(handle: IdleHandle) {
     unsafe {
         let data: *mut raw::c_void = handle as *mut raw::c_void;
@@ -265,7 +266,7 @@ pub fn remove_idle3(handle: IdleHandle) {
     }
 }
 
-/// Checks whether an idle function is installed
+/// Checks whether the idle function, associated with the handle, is installed
 pub fn has_idle3(handle: IdleHandle) -> bool {
     unsafe {
         let data: *mut raw::c_void = handle as *mut raw::c_void;
@@ -535,6 +536,7 @@ unsafe extern "C" fn timeout_shim(data: *mut raw::c_void) {
 
 /**
     Adds a one-shot timeout callback. The timeout duration `tm` is indicated in seconds
+    This function returns a handle that can be use for future interaction with the timeout
     Example:
     ```rust,no_run
     use fltk::{prelude::*, *};
@@ -564,7 +566,7 @@ pub fn add_timeout3<F: FnMut(TimeoutHandle) + 'static>(tm: f64, cb: F) -> Timeou
 }
 
 /**
-    Repeats a timeout callback from the expiration of the previous timeout.
+    Repeats the timeout callback, associated with the hadle, from the expiration of the previous timeout.
     You may only call this method inside a timeout callback.
     The timeout duration `tm` is indicated in seconds
     Example:
@@ -594,7 +596,7 @@ pub fn repeat_timeout3(tm: f64, handle: TimeoutHandle) {
 }
 
 /**
-    Removes a timeout callback
+    Removes the timeout callback associated with the handle
     ```rust,no_run
     use fltk::{prelude::*, *};
     fn main() {

--- a/fltk/src/app/rt.rs
+++ b/fltk/src/app/rt.rs
@@ -275,26 +275,24 @@ pub fn has_idle2(cb: fn()) -> bool {
 }
 
 unsafe extern "C" fn timeout_shim(data: *mut raw::c_void) {
-    let a: *mut Box<dyn FnMut()> = data as *mut Box<dyn FnMut()>;
-    let f: &mut (dyn FnMut()) = &mut **a;
-    let _ = panic::catch_unwind(panic::AssertUnwindSafe(f));
+    let a: *mut Box<dyn FnMut(*mut Box<dyn FnMut()>)> =
+        data as *mut Box<dyn FnMut(*mut Box<dyn FnMut()>)>;
+    let f: &mut (dyn FnMut(*mut Box<dyn FnMut()>)) = &mut **a;
+    let _ = panic::catch_unwind(panic::AssertUnwindSafe(|| (*f)(data as _)));
 }
 
-pub fn add_timeout3<F: FnMut() + 'static>(tm: f64, cb: F) -> *mut Box<dyn FnMut()> {
+pub fn add_timeout3<F: FnMut(*mut Box<dyn FnMut()>) + 'static>(
+    tm: f64,
+    cb: F,
+) -> *mut Box<dyn FnMut()> {
     unsafe {
         assert!(crate::app::is_ui_thread());
-        let a: *mut Box<dyn FnMut()> = Box::into_raw(Box::new(Box::new(cb)));
+        let a: *mut Box<dyn FnMut(*mut Box<dyn FnMut()>)> = Box::into_raw(Box::new(Box::new(cb)));
         let data: *mut raw::c_void = a as *mut raw::c_void;
         let callback: Option<unsafe extern "C" fn(arg1: *mut raw::c_void)> = Some(timeout_shim);
         fl::Fl_add_timeout(tm, callback, data);
 
-        // analysis of the shim function and data variable
-        println!(
-            "A --> shim: {:p}, data: {:p}",
-            timeout_shim as *const (), data
-        );
-
-        a
+        data as _
     }
 }
 
@@ -304,12 +302,15 @@ pub fn remove_timeout3(cb: *mut Box<dyn FnMut()>) {
         let data: *mut raw::c_void = cb as *mut raw::c_void;
         let callback: Option<unsafe extern "C" fn(arg1: *mut raw::c_void)> = Some(timeout_shim);
         fl::Fl_remove_timeout(callback, data);
+    }
+}
 
-        // analysis of the shim function and data variable
-        println!(
-            "R --> shim: {:p}, data: {:p}",
-            timeout_shim as *const (), data
-        );
+pub fn repeat_timeout3(tm: f64, cb: *mut Box<dyn FnMut()>) {
+    assert!(crate::app::is_ui_thread());
+    unsafe {
+        let data: *mut raw::c_void = cb as *mut raw::c_void;
+        let callback: Option<unsafe extern "C" fn(arg1: *mut raw::c_void)> = Some(timeout_shim);
+        fl::Fl_repeat_timeout(tm, callback, data);
     }
 }
 

--- a/fltk/src/app/rt.rs
+++ b/fltk/src/app/rt.rs
@@ -224,6 +224,56 @@ pub fn remove_idle2(cb: fn()) {
     }
 }
 
+/// Checks whether an idle function is installed
+pub fn has_idle2(cb: fn()) -> bool {
+    unsafe {
+        let data: *mut raw::c_void = std::ptr::null_mut();
+        let callback: Option<unsafe extern "C" fn(arg1: *mut raw::c_void)> =
+            Some(mem::transmute(cb));
+        fl::Fl_has_idle(callback, data) != 0
+    }
+}
+
+/// Handle object for interacting with idle callbacks
+pub type IdleHandle = *mut Box<dyn FnMut()>;
+
+unsafe extern "C" fn idle_shim(data: *mut raw::c_void) {
+    let a: *mut Box<dyn FnMut(IdleHandle)> = data as *mut Box<dyn FnMut(IdleHandle)>;
+    let f: &mut (dyn FnMut(IdleHandle)) = &mut **a;
+    let _ = panic::catch_unwind(panic::AssertUnwindSafe(|| (*f)(data as _)));
+}
+
+/// Add an idle callback to run within the event loop.
+/// Calls to `WidgetExt::redraw` within the callback require an explicit sleep
+pub fn add_idle3<F: FnMut(IdleHandle) + 'static>(cb: F) -> IdleHandle {
+    unsafe {
+        let a: *mut Box<dyn FnMut(IdleHandle)> = Box::into_raw(Box::new(Box::new(cb)));
+        let data: *mut raw::c_void = a as *mut raw::c_void;
+        let callback: Option<unsafe extern "C" fn(arg1: *mut raw::c_void)> = Some(idle_shim);
+        fl::Fl_add_idle(callback, data);
+
+        data as _
+    }
+}
+
+/// Remove an idle function
+pub fn remove_idle3(handle: IdleHandle) {
+    unsafe {
+        let data: *mut raw::c_void = handle as *mut raw::c_void;
+        let callback: Option<unsafe extern "C" fn(arg1: *mut raw::c_void)> = Some(idle_shim);
+        fl::Fl_remove_idle(callback, data);
+    }
+}
+
+/// Checks whether an idle function is installed
+pub fn has_idle3(handle: IdleHandle) -> bool {
+    unsafe {
+        let data: *mut raw::c_void = handle as *mut raw::c_void;
+        let callback: Option<unsafe extern "C" fn(arg1: *mut raw::c_void)> = Some(idle_shim);
+        fl::Fl_has_idle(callback, data) != 0
+    }
+}
+
 /// Register a callback whenever there is a change to the selection buffer or the clipboard.
 /// The clipboard is source 1 and the selection buffer is source 0
 pub fn add_clipboard_notify(cb: fn(source: i32)) {
@@ -232,6 +282,17 @@ pub fn add_clipboard_notify(cb: fn(source: i32)) {
         let callback: Option<unsafe extern "C" fn(source: i32, arg1: *mut raw::c_void)> =
             Some(mem::transmute(cb));
         fl::Fl_add_clipboard_notify(callback, data);
+    }
+}
+
+/// Stop calling the specified callback when there are changes to the selection
+/// buffer or the clipboard.
+/// The clipboard is source 1 and the selection buffer is source 0
+pub fn remove_clipboard_notify(cb: fn(source: i32)) {
+    unsafe {
+        let callback: Option<unsafe extern "C" fn(source: i32, arg1: *mut raw::c_void)> =
+            Some(mem::transmute(cb));
+        fl::Fl_remove_clipboard_notify(callback);
     }
 }
 
@@ -253,64 +314,33 @@ pub fn add_clipboard_notify2<F: FnMut(i32) + 'static>(cb: F) {
     }
 }
 
+unsafe extern "C" fn clipboard_notify_shim(source: i32, data: *mut raw::c_void) {
+    let a: *mut Box<dyn FnMut(i32)> = data as *mut Box<dyn FnMut(i32)>;
+    let f: &mut (dyn FnMut(i32)) = &mut **a;
+    let _ = panic::catch_unwind(panic::AssertUnwindSafe(|| (*f)(source)));
+}
+
+/// Register a callback whenever there is a change to the selection buffer or the clipboard.
+/// The clipboard is source 1 and the selection buffer is source 0.
+/// A callback via closure cannot be removed!
+pub fn add_clipboard_notify3<F: FnMut(i32) + 'static>(cb: F) {
+    unsafe {
+        let a: *mut Box<dyn FnMut(i32)> = Box::into_raw(Box::new(Box::new(cb)));
+        let data: *mut raw::c_void = a as *mut raw::c_void;
+        let callback: Option<unsafe extern "C" fn(source: i32, arg1: *mut raw::c_void)> =
+            Some(clipboard_notify_shim);
+        fl::Fl_add_clipboard_notify(callback, data);
+    }
+}
+
 /// Stop calling the specified callback when there are changes to the selection
 /// buffer or the clipboard.
 /// The clipboard is source 1 and the selection buffer is source 0
-pub fn remove_clipboard_notify(cb: fn(source: i32)) {
+pub fn remove_clipboard_notify3() {
     unsafe {
         let callback: Option<unsafe extern "C" fn(source: i32, arg1: *mut raw::c_void)> =
-            Some(mem::transmute(cb));
+            Some(clipboard_notify_shim);
         fl::Fl_remove_clipboard_notify(callback);
-    }
-}
-
-/// Checks whether an idle function is installed
-pub fn has_idle2(cb: fn()) -> bool {
-    unsafe {
-        let data: *mut raw::c_void = std::ptr::null_mut();
-        let callback: Option<unsafe extern "C" fn(arg1: *mut raw::c_void)> =
-            Some(mem::transmute(cb));
-        fl::Fl_has_idle(callback, data) != 0
-    }
-}
-
-unsafe extern "C" fn timeout_shim(data: *mut raw::c_void) {
-    let a: *mut Box<dyn FnMut(*mut Box<dyn FnMut()>)> =
-        data as *mut Box<dyn FnMut(*mut Box<dyn FnMut()>)>;
-    let f: &mut (dyn FnMut(*mut Box<dyn FnMut()>)) = &mut **a;
-    let _ = panic::catch_unwind(panic::AssertUnwindSafe(|| (*f)(data as _)));
-}
-
-pub fn add_timeout3<F: FnMut(*mut Box<dyn FnMut()>) + 'static>(
-    tm: f64,
-    cb: F,
-) -> *mut Box<dyn FnMut()> {
-    unsafe {
-        assert!(crate::app::is_ui_thread());
-        let a: *mut Box<dyn FnMut(*mut Box<dyn FnMut()>)> = Box::into_raw(Box::new(Box::new(cb)));
-        let data: *mut raw::c_void = a as *mut raw::c_void;
-        let callback: Option<unsafe extern "C" fn(arg1: *mut raw::c_void)> = Some(timeout_shim);
-        fl::Fl_add_timeout(tm, callback, data);
-
-        data as _
-    }
-}
-
-pub fn remove_timeout3(cb: *mut Box<dyn FnMut()>) {
-    assert!(crate::app::is_ui_thread());
-    unsafe {
-        let data: *mut raw::c_void = cb as *mut raw::c_void;
-        let callback: Option<unsafe extern "C" fn(arg1: *mut raw::c_void)> = Some(timeout_shim);
-        fl::Fl_remove_timeout(callback, data);
-    }
-}
-
-pub fn repeat_timeout3(tm: f64, cb: *mut Box<dyn FnMut()>) {
-    assert!(crate::app::is_ui_thread());
-    unsafe {
-        let data: *mut raw::c_void = cb as *mut raw::c_void;
-        let callback: Option<unsafe extern "C" fn(arg1: *mut raw::c_void)> = Some(timeout_shim);
-        fl::Fl_repeat_timeout(tm, callback, data);
     }
 }
 
@@ -490,6 +520,152 @@ pub fn has_timeout2(cb: fn()) -> bool {
         let data: *mut raw::c_void = std::ptr::null_mut();
         let callback: Option<unsafe extern "C" fn(arg1: *mut raw::c_void)> =
             Some(mem::transmute(cb));
+        fl::Fl_has_timeout(callback, data) != 0
+    }
+}
+
+/// Handle object for interacting with timeouts
+pub type TimeoutHandle = *mut Box<dyn FnMut()>;
+
+unsafe extern "C" fn timeout_shim(data: *mut raw::c_void) {
+    let a: *mut Box<dyn FnMut(TimeoutHandle)> = data as *mut Box<dyn FnMut(TimeoutHandle)>;
+    let f: &mut (dyn FnMut(TimeoutHandle)) = &mut **a;
+    let _ = panic::catch_unwind(panic::AssertUnwindSafe(|| (*f)(data as _)));
+}
+
+/**
+    Adds a one-shot timeout callback. The timeout duration `tm` is indicated in seconds
+    Example:
+    ```rust,no_run
+    use fltk::{prelude::*, *};
+    fn main() {
+        let callback = |_handle| {
+            println!("FIRED");
+        };
+
+        let app = app::App::default();
+        let mut wind = window::Window::new(100, 100, 400, 300, "");
+        wind.show();
+        let _handle = app::add_timeout3(1.0, callback);
+        app.run().unwrap();
+    }
+    ```
+*/
+pub fn add_timeout3<F: FnMut(TimeoutHandle) + 'static>(tm: f64, cb: F) -> TimeoutHandle {
+    assert!(crate::app::is_ui_thread());
+    unsafe {
+        let a: *mut Box<dyn FnMut(TimeoutHandle)> = Box::into_raw(Box::new(Box::new(cb)));
+        let data: *mut raw::c_void = a as *mut raw::c_void;
+        let callback: Option<unsafe extern "C" fn(arg1: *mut raw::c_void)> = Some(timeout_shim);
+        fl::Fl_add_timeout(tm, callback, data);
+
+        data as _
+    }
+}
+
+/**
+    Repeats a timeout callback from the expiration of the previous timeout.
+    You may only call this method inside a timeout callback.
+    The timeout duration `tm` is indicated in seconds
+    Example:
+    ```rust,no_run
+    use fltk::{prelude::*, *};
+    fn main() {
+        let callback = |handle| {
+            println!("TICK");
+            app::repeat_timeout3(1.0, handle);
+        };
+
+        let app = app::App::default();
+        let mut wind = window::Window::new(100, 100, 400, 300, "");
+        wind.show();
+        app::add_timeout3(1.0, callback);
+        app.run().unwrap();
+    }
+    ```
+*/
+pub fn repeat_timeout3(tm: f64, handle: TimeoutHandle) {
+    assert!(crate::app::is_ui_thread());
+    unsafe {
+        let data: *mut raw::c_void = handle as *mut raw::c_void;
+        let callback: Option<unsafe extern "C" fn(arg1: *mut raw::c_void)> = Some(timeout_shim);
+        fl::Fl_repeat_timeout(tm, callback, data);
+    }
+}
+
+/**
+    Removes a timeout callback
+    ```rust,no_run
+    use fltk::{prelude::*, *};
+    fn main() {
+        let callback = |handle| {
+            println!("FIRED");
+        };
+
+        let app = app::App::default();
+        let mut wind = window::Window::new(100, 100, 400, 300, "");
+        wind.show();
+        let handle = app::add_timeout3(1.0, callback);
+        app::remove_timeout3(handle);
+        app.run().unwrap();
+    }
+    ```
+*/
+pub fn remove_timeout3(handle: TimeoutHandle) {
+    assert!(crate::app::is_ui_thread());
+    unsafe {
+        let data: *mut raw::c_void = handle as *mut raw::c_void;
+        let callback: Option<unsafe extern "C" fn(arg1: *mut raw::c_void)> = Some(timeout_shim);
+        fl::Fl_remove_timeout(callback, data);
+    }
+}
+
+/// Check whether the timeout, associated with the handle, is installed
+pub fn has_timeout3(handle: TimeoutHandle) -> bool {
+    assert!(crate::app::is_ui_thread());
+    unsafe {
+        let data: *mut raw::c_void = handle as *mut raw::c_void;
+        let callback: Option<unsafe extern "C" fn(arg1: *mut raw::c_void)> = Some(timeout_shim);
+        fl::Fl_has_timeout(callback, data) != 0
+    }
+}
+
+#[doc(hidden)]
+pub fn add_raw_timeout<T>(tm: f64, cb: fn(*mut T), data: *mut T) {
+    unsafe {
+        let callback: Option<unsafe extern "C" fn(arg1: *mut raw::c_void)> =
+            Some(mem::transmute(cb));
+        let data: *mut raw::c_void = data as *mut raw::c_void;
+        fl::Fl_add_timeout(tm, callback, data);
+    }
+}
+
+#[doc(hidden)]
+pub fn repeat_raw_timeout<T>(tm: f64, cb: fn(*mut T), data: *mut T) {
+    unsafe {
+        let callback: Option<unsafe extern "C" fn(arg1: *mut raw::c_void)> =
+            Some(mem::transmute(cb));
+        let data: *mut raw::c_void = data as *mut raw::c_void;
+        fl::Fl_repeat_timeout(tm, callback, data);
+    }
+}
+
+#[doc(hidden)]
+pub fn remove_raw_timeout<T>(cb: fn(*mut T), data: *mut T) {
+    unsafe {
+        let callback: Option<unsafe extern "C" fn(arg1: *mut raw::c_void)> =
+            Some(mem::transmute(cb));
+        let data: *mut raw::c_void = data as *mut raw::c_void;
+        fl::Fl_remove_timeout(callback, data);
+    }
+}
+
+#[doc(hidden)]
+pub fn has_raw_timeout<T>(cb: fn(*mut T), data: *mut T) -> bool {
+    unsafe {
+        let callback: Option<unsafe extern "C" fn(arg1: *mut raw::c_void)> =
+            Some(mem::transmute(cb));
+        let data: *mut raw::c_void = data as *mut raw::c_void;
         fl::Fl_has_timeout(callback, data) != 0
     }
 }


### PR DESCRIPTION
This PR introduces several new functions as alternatives to: `*_timeout()`, `*_idle()`, and `*_clipboard_notify2()`; as a way to correctly manage closures that are used as callbacks in those contexts. As discussed previously, these functions all employ a handle-based mechanism, with the exception of the `*_clipboard_notify3()` functions, where it's mostly unnecessary.
I've also included a set of `*_raw_timeout()` functions that provide more low-level interaction with the C API. Ultimately, they may not be needed, but I included them since the handle-based functions do not exactly mimic the behavior of the underlying C API. 
The difference being that the handle-based functions are only capable of removing one callback at a time, whereas, the underlying API permits the removal of all matching callbacks (see the [documentation](https://www.fltk.org/doc-1.3/classFl.html#a9a950f0585de6416eb4fee2365a1578f)).