### PR TITLE
Manually implement Clone for app::channel::{Sender, Receiver}

### DIFF
--- a/fltk/src/app/channel.rs
+++ b/fltk/src/app/channel.rs
@@ -43,11 +43,22 @@ struct Message<T: Send + Sync> {
 }
 
 /// Creates a sender struct
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Copy)]
 pub struct Sender<T: Send + Sync> {
     data: marker::PhantomData<T>,
     hash: u64,
     sz: usize,
+}
+
+// Manually create the impl so there's no Clone bound on T
+impl<T: Send + Sync> Clone for Sender<T> {
+  fn clone(&self) -> Self {
+    Sender {
+      data: marker::PhantomData,
+      hash: self.hash.clone(),
+      sz: self.sz.clone()
+    }
+  }
 }
 
 impl<T: Send + Sync> Sender<T> {
@@ -69,11 +80,22 @@ impl<T: Send + Sync> Sender<T> {
 }
 
 /// Creates a receiver struct
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Copy)]
 pub struct Receiver<T: Send + Sync> {
     data: marker::PhantomData<T>,
     hash: u64,
     sz: usize,
+}
+//
+// Manually create the impl so there's no Clone bound on T
+impl<T: Send + Sync> Clone for Receiver<T> {
+  fn clone(&self) -> Self {
+    Receiver {
+      data: marker::PhantomData,
+      hash: self.hash.clone(),
+      sz: self.sz.clone()
+    }
+  }
 }
 
 impl<T: Send + Sync> Receiver<T> {


### PR DESCRIPTION
The derive macro demands a `Clone` bound on all type parameters, and
there's no reason to restrict messaging to `Clone` types. I had to work around this when making my app use messaging more, since threads & windows OS don't mix as well as I would have liked :) I could easily work around by making my messages `Clone`, but this seems like a general improvement to me, hence this PR :)