### PR TITLE
1.2.29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add TextEditor::AnyState const value.
 - Add TextEditor::add_key_binding() and remove_key_binding().
 - Fix for unicode fonts.
+- Pull FLTK menu fixes.
 - Update FLTK (removes experimental drivers).
 
 ## [1.2.28] - 2022-01-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
 
 
-## [1.2.29] - Unreleased
+## [1.2.29] - 2022-01-31
 - Add TextEditor::AnyState const value.
 - Add TextEditor::add_key_binding() and remove_key_binding().
+- Add TextBuffer methods of secondary selection.
 - Fix for unicode fonts.
 - Add DisplayExt::set_highlight_data_ext() and text::StyleTableEntryExt (supports underline, strikethrough, background color...etc).
 - Pull FLTK menu fixes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add TextBuffer methods of secondary selection.
 - Fix for unicode fonts.
 - Add DisplayExt::set_highlight_data_ext() and text::StyleTableEntryExt (supports underline, strikethrough, background color...etc).
+- Add setters & getters for secondary selection, spelling and grammar colors.
 - Pull FLTK menu fixes.
 - Update FLTK (removes experimental drivers).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add TextEditor::AnyState const value.
 - Add TextEditor::add_key_binding() and remove_key_binding().
 - Fix for unicode fonts.
+- Add DisplayExt::set_highlight_data_ext() and text::StyleTableEntryExt (supports underline, strikethrough, background color...etc).
 - Pull FLTK menu fixes.
 - Update FLTK (removes experimental drivers).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 
+## [1.2.29] - Unreleased
+- Add TextEditor::AnyState const value.
+- Add TextEditor::add_key_binding() and remove_key_binding().
+
 ## [1.2.28] - 2022-01-22
 - Expose TreeItem user_data.
 - Documentation fix by @AshfordN.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 ## [1.2.29] - Unreleased
 - Add TextEditor::AnyState const value.
 - Add TextEditor::add_key_binding() and remove_key_binding().
+- Fix for unicode fonts.
+- Update FLTK (removes experimental drivers).
 
 ## [1.2.28] - 2022-01-22
 - Expose TreeItem user_data.

--- a/README.md
+++ b/README.md
@@ -491,7 +491,6 @@ Various advanced examples can also be found [here](https://github.com/wyhinton/F
 - [Drawing things with fltk](https://www.youtube.com/watch?v=r9MOpvfBPWs)
 - [Working with images](https://www.youtube.com/watch?v=Rn2sjfAX4WI)
 - [Audio player with custom widgets](https://www.youtube.com/watch?v=okdFx6tv7ds)
-- [Using FLTK on Android](https://www.youtube.com/watch?v=3jW_vxGmxt0)
 - [Use FLUID (RAD tool) with Rust](https://www.youtube.com/watch?v=k_P0wG3-dNk)
 - [multiple windows and embedding windows](https://www.youtube.com/watch?v=qEPYx1Lw7fY)
 - [FLTK Rust tutorial: Improve FLTK's toggle button appearance!](https://www.youtube.com/watch?v=WCTbPKHXR-o)

--- a/fltk-sys/Cargo.toml
+++ b/fltk-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk-sys"
-version = "1.2.28"
+version = "1.2.29"
 authors = ["The fltk-rs Authors"]
 build = "build/main.rs"
 edition = "2018"

--- a/fltk-sys/src/text.rs
+++ b/fltk-sys/src/text.rs
@@ -881,6 +881,39 @@ extern "C" {
         row: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
+extern "C" {
+    pub fn Fl_Text_Display_set_grammar_underline_color(
+        self_: *mut Fl_Text_Display,
+        color: ::std::os::raw::c_uint,
+    );
+}
+extern "C" {
+    pub fn Fl_Text_Display_grammar_underline_color(
+        self_: *const Fl_Text_Display,
+    ) -> ::std::os::raw::c_uint;
+}
+extern "C" {
+    pub fn Fl_Text_Display_set_spelling_underline_color(
+        self_: *mut Fl_Text_Display,
+        color: ::std::os::raw::c_uint,
+    );
+}
+extern "C" {
+    pub fn Fl_Text_Display_spelling_underline_color(
+        self_: *const Fl_Text_Display,
+    ) -> ::std::os::raw::c_uint;
+}
+extern "C" {
+    pub fn Fl_Text_Display_set_secondary_selection_color(
+        self_: *mut Fl_Text_Display,
+        color: ::std::os::raw::c_uint,
+    );
+}
+extern "C" {
+    pub fn Fl_Text_Display_secondary_selection_color(
+        self_: *const Fl_Text_Display,
+    ) -> ::std::os::raw::c_uint;
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct Fl_Text_Editor {
@@ -1455,6 +1488,39 @@ extern "C" {
         self_: *const Fl_Text_Editor,
         row: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn Fl_Text_Editor_set_grammar_underline_color(
+        self_: *mut Fl_Text_Editor,
+        color: ::std::os::raw::c_uint,
+    );
+}
+extern "C" {
+    pub fn Fl_Text_Editor_grammar_underline_color(
+        self_: *const Fl_Text_Editor,
+    ) -> ::std::os::raw::c_uint;
+}
+extern "C" {
+    pub fn Fl_Text_Editor_set_spelling_underline_color(
+        self_: *mut Fl_Text_Editor,
+        color: ::std::os::raw::c_uint,
+    );
+}
+extern "C" {
+    pub fn Fl_Text_Editor_spelling_underline_color(
+        self_: *const Fl_Text_Editor,
+    ) -> ::std::os::raw::c_uint;
+}
+extern "C" {
+    pub fn Fl_Text_Editor_set_secondary_selection_color(
+        self_: *mut Fl_Text_Editor,
+        color: ::std::os::raw::c_uint,
+    );
+}
+extern "C" {
+    pub fn Fl_Text_Editor_secondary_selection_color(
+        self_: *const Fl_Text_Editor,
+    ) -> ::std::os::raw::c_uint;
 }
 extern "C" {
     pub fn Fl_Text_Editor_kf_copy(e: *mut Fl_Text_Editor) -> ::std::os::raw::c_int;
@@ -2317,6 +2383,39 @@ extern "C" {
         self_: *const Fl_Simple_Terminal,
         row: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn Fl_Simple_Terminal_set_grammar_underline_color(
+        self_: *mut Fl_Simple_Terminal,
+        color: ::std::os::raw::c_uint,
+    );
+}
+extern "C" {
+    pub fn Fl_Simple_Terminal_grammar_underline_color(
+        self_: *const Fl_Simple_Terminal,
+    ) -> ::std::os::raw::c_uint;
+}
+extern "C" {
+    pub fn Fl_Simple_Terminal_set_spelling_underline_color(
+        self_: *mut Fl_Simple_Terminal,
+        color: ::std::os::raw::c_uint,
+    );
+}
+extern "C" {
+    pub fn Fl_Simple_Terminal_spelling_underline_color(
+        self_: *const Fl_Simple_Terminal,
+    ) -> ::std::os::raw::c_uint;
+}
+extern "C" {
+    pub fn Fl_Simple_Terminal_set_secondary_selection_color(
+        self_: *mut Fl_Simple_Terminal,
+        color: ::std::os::raw::c_uint,
+    );
+}
+extern "C" {
+    pub fn Fl_Simple_Terminal_secondary_selection_color(
+        self_: *const Fl_Simple_Terminal,
+    ) -> ::std::os::raw::c_uint;
 }
 extern "C" {
     pub fn Fl_delete_stable(arg1: *mut ::std::os::raw::c_void);

--- a/fltk-sys/src/text.rs
+++ b/fltk-sys/src/text.rs
@@ -1529,6 +1529,26 @@ extern "C" {
 extern "C" {
     pub fn Fl_Text_Editor_tab_nav(self_: *const Fl_Text_Editor) -> ::std::os::raw::c_int;
 }
+extern "C" {
+    pub fn Fl_Text_Editor_add_key_binding(
+        self_: *mut Fl_Text_Editor,
+        key: ::std::os::raw::c_int,
+        state: ::std::os::raw::c_int,
+        kf: ::std::option::Option<
+            unsafe extern "C" fn(
+                arg1: ::std::os::raw::c_int,
+                arg2: *mut Fl_Text_Editor,
+            ) -> ::std::os::raw::c_int,
+        >,
+    );
+}
+extern "C" {
+    pub fn Fl_Text_Editor_remove_key_binding(
+        self_: *mut Fl_Text_Editor,
+        key: ::std::os::raw::c_int,
+        state: ::std::os::raw::c_int,
+    );
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct Fl_Simple_Terminal {

--- a/fltk-sys/src/text.rs
+++ b/fltk-sys/src/text.rs
@@ -153,6 +153,40 @@ extern "C" {
     );
 }
 extern "C" {
+    pub fn Fl_Text_Buffer_secondary_select(
+        self_: *mut Fl_Text_Buffer,
+        start: ::std::os::raw::c_int,
+        end: ::std::os::raw::c_int,
+    );
+}
+extern "C" {
+    pub fn Fl_Text_Buffer_secondary_selected(self_: *mut Fl_Text_Buffer) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn Fl_Text_Buffer_secondary_unselect(self_: *mut Fl_Text_Buffer);
+}
+extern "C" {
+    pub fn Fl_Text_Buffer_secondary_selection_position(
+        self_: *mut Fl_Text_Buffer,
+        start: *mut ::std::os::raw::c_int,
+        end: *mut ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn Fl_Text_Buffer_secondary_selection_text(
+        self_: *mut Fl_Text_Buffer,
+    ) -> *mut ::std::os::raw::c_char;
+}
+extern "C" {
+    pub fn Fl_Text_Buffer_remove_secondary_selection(self_: *mut Fl_Text_Buffer);
+}
+extern "C" {
+    pub fn Fl_Text_Buffer_replace_secondary_selection(
+        self_: *mut Fl_Text_Buffer,
+        text: *const ::std::os::raw::c_char,
+    );
+}
+extern "C" {
     pub fn Fl_Text_Buffer_highlight(
         self_: *mut Fl_Text_Buffer,
         start: ::std::os::raw::c_int,

--- a/fltk-sys/src/text.rs
+++ b/fltk-sys/src/text.rs
@@ -663,10 +663,12 @@ extern "C" {
 extern "C" {
     pub fn Fl_Text_Display_set_highlight_data(
         self_: *mut Fl_Text_Display,
-        sbuf: *mut ::std::os::raw::c_void,
+        sbuff: *mut ::std::os::raw::c_void,
         color: *mut ::std::os::raw::c_uint,
         font: *mut ::std::os::raw::c_int,
         fontsz: *mut ::std::os::raw::c_int,
+        attr: *mut ::std::os::raw::c_int,
+        bgcolor: *mut ::std::os::raw::c_int,
         sz: ::std::os::raw::c_int,
     );
 }
@@ -1241,10 +1243,12 @@ extern "C" {
 extern "C" {
     pub fn Fl_Text_Editor_set_highlight_data(
         self_: *mut Fl_Text_Editor,
-        sbuf: *mut ::std::os::raw::c_void,
+        sbuff: *mut ::std::os::raw::c_void,
         color: *mut ::std::os::raw::c_uint,
         font: *mut ::std::os::raw::c_int,
         fontsz: *mut ::std::os::raw::c_int,
+        attr: *mut ::std::os::raw::c_int,
+        bgcolor: *mut ::std::os::raw::c_int,
         sz: ::std::os::raw::c_int,
     );
 }
@@ -2085,10 +2089,12 @@ extern "C" {
 extern "C" {
     pub fn Fl_Simple_Terminal_set_highlight_data(
         self_: *mut Fl_Simple_Terminal,
-        sbuf: *mut ::std::os::raw::c_void,
+        sbuff: *mut ::std::os::raw::c_void,
         color: *mut ::std::os::raw::c_uint,
         font: *mut ::std::os::raw::c_int,
         fontsz: *mut ::std::os::raw::c_int,
+        attr: *mut ::std::os::raw::c_int,
+        bgcolor: *mut ::std::os::raw::c_int,
         sz: ::std::os::raw::c_int,
     );
 }

--- a/fltk-sys/src/text.rs
+++ b/fltk-sys/src/text.rs
@@ -667,8 +667,8 @@ extern "C" {
         color: *mut ::std::os::raw::c_uint,
         font: *mut ::std::os::raw::c_int,
         fontsz: *mut ::std::os::raw::c_int,
-        attr: *mut ::std::os::raw::c_int,
-        bgcolor: *mut ::std::os::raw::c_int,
+        attr: *mut ::std::os::raw::c_uint,
+        bgcolor: *mut ::std::os::raw::c_uint,
         sz: ::std::os::raw::c_int,
     );
 }
@@ -1247,8 +1247,8 @@ extern "C" {
         color: *mut ::std::os::raw::c_uint,
         font: *mut ::std::os::raw::c_int,
         fontsz: *mut ::std::os::raw::c_int,
-        attr: *mut ::std::os::raw::c_int,
-        bgcolor: *mut ::std::os::raw::c_int,
+        attr: *mut ::std::os::raw::c_uint,
+        bgcolor: *mut ::std::os::raw::c_uint,
         sz: ::std::os::raw::c_int,
     );
 }
@@ -2093,8 +2093,8 @@ extern "C" {
         color: *mut ::std::os::raw::c_uint,
         font: *mut ::std::os::raw::c_int,
         fontsz: *mut ::std::os::raw::c_int,
-        attr: *mut ::std::os::raw::c_int,
-        bgcolor: *mut ::std::os::raw::c_int,
+        attr: *mut ::std::os::raw::c_uint,
+        bgcolor: *mut ::std::os::raw::c_uint,
         sz: ::std::os::raw::c_int,
     );
 }

--- a/fltk/Cargo.toml
+++ b/fltk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk"
-version = "1.2.28"
+version = "1.2.29"
 authors = ["The fltk-rs Authors"]
 edition = "2018"
 description = "Rust bindings for the FLTK GUI library"
@@ -17,7 +17,7 @@ name = "fltk"
 path = "src/lib.rs"
 
 [dependencies]
-fltk-sys = { path = "../fltk-sys", version = "=1.2.28" }
+fltk-sys = { path = "../fltk-sys", version = "=1.2.29" }
 bitflags = "^1.3"
 paste = "1"
 crossbeam-channel = "0.5"

--- a/fltk/examples/closable_tab.rs
+++ b/fltk/examples/closable_tab.rs
@@ -1,7 +1,9 @@
+#![allow(dead_code)]
+
 mod closable_tab {
     use fltk::{
         app, button,
-        enums::{Align, Color, Event, FrameType},
+        enums::{Align, Color, FrameType},
         group,
         prelude::*,
     };
@@ -54,13 +56,13 @@ mod closable_tab {
         pub fn add(&mut self, child: & mut group::Group, label: &str) {
             child.resize(self.contents.x(), self.contents.y(), self.contents.w(), self.contents.h());
             self.contents.add(child);
-            let mut but = create_tab_button(&label);
+            let but = create_tab_button(&label);
             self.tab_labels.add(&but);
             but.child(1).unwrap().set_callback({
                 let curr_child = child.clone();
-                let mut contents = self.contents.clone();
+                let contents = self.contents.clone();
                 let sndb         = self.snd.clone();
-                move |x| {
+                move |_| {
                     let idx = contents.find(&curr_child);
                     sndb.send(Message::DeleteTab(idx));
                     app::redraw();
@@ -68,9 +70,9 @@ mod closable_tab {
             });
             but.child(0).unwrap().set_callback({
                 let curr_child = child.clone();
-                let mut contents = self.contents.clone();
+                let contents = self.contents.clone();
                 let sndb         = self.snd.clone();
-                move |x| {
+                move |_| {
                     let idx = contents.find(&curr_child);
                     sndb.send(Message::ForegroundTab(idx));
                     app::redraw();
@@ -153,7 +155,7 @@ fn main() {
                 DeleteTab(idx) => {
                     tabs.remove(idx);
                 },
-                InsertNewTab(i32) => {},
+                InsertNewTab(_) => {},
             }
         }
     }

--- a/fltk/examples/hello_button.rs
+++ b/fltk/examples/hello_button.rs
@@ -7,7 +7,7 @@ fn main() {
     let mut but = Button::new(160, 210, 80, 40, "Click me!");
     wind.end();
     wind.show();
-    but.deactivate();
+
     but.set_callback(move |_| frame.set_label("Hello world"));
 
     app.run().unwrap();

--- a/fltk/src/app/font.rs
+++ b/fltk/src/app/font.rs
@@ -135,7 +135,7 @@ pub(crate) fn load_font(path: &str) -> Result<String, FltkError> {
         let family_name = face
             .names()
             .into_iter()
-            .find(|name| name.name_id == ttf_parser::name_id::FULL_NAME)
+            .find(|name| name.name_id == ttf_parser::name_id::FULL_NAME && name.is_unicode())
             .and_then(|name| name.to_string());
         let path = CString::new(path)?;
         let ret = fl::Fl_load_font(path.as_ptr());

--- a/fltk/src/enums.rs
+++ b/fltk/src/enums.rs
@@ -367,7 +367,7 @@ impl Font {
                 let family_name = face
                     .names()
                     .into_iter()
-                    .find(|name| name.name_id == ttf_parser::name_id::FULL_NAME)
+                    .find(|name| name.name_id == ttf_parser::name_id::FULL_NAME && name.is_unicode())
                     .and_then(|name| name.to_string());
                 let path = CString::safe_new(p);
                 let ret = fl::Fl_load_font(path.as_ptr());

--- a/fltk/src/macros/display.rs
+++ b/fltk/src/macros/display.rs
@@ -271,12 +271,16 @@ macro_rules! impl_display_ext {
                         let mut colors = [$crate::enums::Color::Black.bits()];
                         let mut fonts = [$crate::enums::Font::Helvetica.bits()];
                         let mut sizes = [14];
+                        let mut attrs = [0];
+                        let mut bgcols = [0];
                         [<$flname _set_highlight_data>](
                             self.inner,
                             style_buffer.as_ptr() as *mut raw::c_void,
                             colors.as_mut_ptr(),
                             fonts.as_mut_ptr(),
                             sizes.as_mut_ptr(),
+                            attrs.as_mut_ptr(),
+                            bgcols.as_mut_ptr(),
                             1,
                         )
                     }

--- a/fltk/src/macros/display.rs
+++ b/fltk/src/macros/display.rs
@@ -277,7 +277,7 @@ macro_rules! impl_display_ext {
                             color: $crate::enums::Color::Black,
                             font: $crate::enums::Font::Helvetica,
                             size: $crate::app::font_size(),
-                            attr: $crate::text::Attr::None,
+                            attr: $crate::text::TextAttr::None,
                             bgcolor: $crate::enums::Color::Black,
                         }]
                     } else {

--- a/fltk/src/macros/display.rs
+++ b/fltk/src/macros/display.rs
@@ -612,6 +612,48 @@ macro_rules! impl_display_ext {
                     assert!(self.buffer().is_some());
                     unsafe { [<$flname _wrapped_row>](self.inner, row) }
                 }
+
+                fn set_grammar_underline_color(&mut self, color: $crate::enums::Color) {
+                    assert!(self.was_deleted());
+                    unsafe {
+                        [<$flname _set_grammar_underline_color>](self.inner, color.bits() as u32)
+                    }
+                }
+
+                fn grammar_underline_color(&self) -> $crate::enums::Color {
+                    assert!(self.was_deleted());
+                    unsafe {
+                        std::mem::transmute([<$flname _grammar_underline_color>](self.inner))
+                    }
+                }
+
+                fn set_spelling_underline_color(&mut self, color: $crate::enums::Color) {
+                    assert!(self.was_deleted());
+                    unsafe {
+                        [<$flname _set_spelling_underline_color>](self.inner, color.bits() as u32)
+                    }
+                }
+
+                fn spelling_underline_color(&self) -> $crate::enums::Color {
+                    assert!(self.was_deleted());
+                    unsafe {
+                        std::mem::transmute([<$flname _spelling_underline_color>](self.inner))
+                    }
+                }
+
+                fn set_secondary_selection_color(&mut self, color: $crate::enums::Color) {
+                    assert!(self.was_deleted());
+                    unsafe {
+                        [<$flname _set_secondary_selection_color>](self.inner, color.bits() as u32)
+                    }
+                }
+
+                fn secondary_selection_color(&self) -> $crate::enums::Color {
+                    assert!(self.was_deleted());
+                    unsafe {
+                        std::mem::transmute([<$flname _secondary_selection_color>](self.inner))
+                    }
+                }
             }
         }
     };

--- a/fltk/src/macros/display.rs
+++ b/fltk/src/macros/display.rs
@@ -223,10 +223,14 @@ macro_rules! impl_display_ext {
                     let mut colors: Vec<u32> = vec![];
                     let mut fonts: Vec<i32> = vec![];
                     let mut sizes: Vec<i32> = vec![];
+                    let mut attrs: Vec<i32> = vec![];
+                    let mut bgcols: Vec<i32> = vec![];
                     for entry in entries.iter() {
                         colors.push(entry.color.bits() as u32);
                         fonts.push(entry.font.bits() as i32);
                         sizes.push(entry.size as i32);
+                        attrs.push(0);
+                        bgcols.push(0);
                     }
                     let style_buffer = style_buffer.into();
                     if let Some(style_buffer) = style_buffer {
@@ -238,6 +242,8 @@ macro_rules! impl_display_ext {
                                 colors.as_mut_ptr(),
                                 fonts.as_mut_ptr(),
                                 sizes.as_mut_ptr(),
+                                attrs.as_mut_ptr(),
+                                bgcols.as_mut_ptr(),
                                 entries.len() as i32,
                             )
                         }
@@ -249,6 +255,8 @@ macro_rules! impl_display_ext {
                                     buf.as_ptr() as _,
                                     colors.as_mut_ptr(),
                                     fonts.as_mut_ptr(),
+                                    attrs.as_mut_ptr(),
+                                    bgcols.as_mut_ptr(),
                                     sizes.as_mut_ptr(),
                                     1,
                                 )

--- a/fltk/src/prelude.rs
+++ b/fltk/src/prelude.rs
@@ -1081,6 +1081,12 @@ pub unsafe trait DisplayExt: WidgetExt {
         style_buffer: B,
         entries: Vec<crate::text::StyleTableEntry>,
     );
+    /// Sets the style of the text widget
+    fn set_highlight_data_ext<B: Into<Option<crate::text::TextBuffer>>>(
+        &mut self,
+        style_buffer: B,
+        entries: Vec<crate::text::StyleTableEntryExt>,
+    );
     /// Unset the style of the text widget
     fn unset_highlight_data(&mut self, style_buffer: crate::text::TextBuffer);
     /// Sets the cursor style

--- a/fltk/src/prelude.rs
+++ b/fltk/src/prelude.rs
@@ -1162,6 +1162,18 @@ pub unsafe trait DisplayExt: WidgetExt {
     fn wrapped_column(&self, row: i32, column: i32) -> i32;
     /// Correct a row number from an unconstrained position
     fn wrapped_row(&self, row: i32) -> i32;
+    /// Set the grammar underline color
+    fn set_grammar_underline_color(&mut self, color: Color);
+    /// Get the grammar underline color
+    fn grammar_underline_color(&self) -> Color;
+    /// Set the spelling underline color
+    fn set_spelling_underline_color(&mut self, color: Color);
+    /// Get the spelling underline color
+    fn spelling_underline_color(&self) -> Color;
+    /// Set the secondary selection color
+    fn set_secondary_selection_color(&mut self, color: Color);
+    /// Get the secondary selection color
+    fn secondary_selection_color(&self) -> Color;
 }
 
 /// Defines the methods implemented by all browser types

--- a/fltk/src/text.rs
+++ b/fltk/src/text.rs
@@ -665,6 +665,9 @@ crate::macros::widget::impl_widget_ext!(TextEditor, Fl_Text_Editor);
 crate::macros::widget::impl_widget_base!(TextEditor, Fl_Text_Editor);
 crate::macros::display::impl_display_ext!(TextEditor, Fl_Text_Editor);
 
+/// Alias Fl_Text_Editor for use in `add_key_binding`
+pub type TextEditorPtr = *mut Fl_Text_Editor;
+
 /// Creates an editable text display widget to handle terminal-like behavior, such as
 /// logging events or debug information.
 /// `SimpleTerminal` already has an internal buffer.
@@ -956,7 +959,7 @@ impl TextEditor {
         &mut self,
         key: crate::enums::Key,
         shortcut: crate::enums::Shortcut,
-        cb: fn(key: crate::enums::Key, editor: *mut Fl_Text_Editor) -> i32,
+        cb: fn(key: crate::enums::Key, editor: TextEditorPtr) -> i32,
     ) {
         assert!(!self.was_deleted());
         unsafe {

--- a/fltk/src/text.rs
+++ b/fltk/src/text.rs
@@ -753,7 +753,7 @@ crate::macros::display::impl_display_ext!(SimpleTerminal, Fl_Simple_Terminal);
 #[derive(Debug, Clone, Copy)]
 #[repr(u32)]
 #[non_exhaustive]
-pub enum Attr {
+pub enum TextAttr {
     /// No attribute
     None = 0x0000,
     /// Use the background color in the `bgcolor` field
@@ -789,7 +789,7 @@ pub struct StyleTableEntryExt {
     /// Font size
     pub size: i32,
     /// attribute
-    pub attr: Attr,
+    pub attr: TextAttr,
     /// background color
     pub bgcolor: Color,
 }

--- a/fltk/src/text.rs
+++ b/fltk/src/text.rs
@@ -686,6 +686,26 @@ crate::macros::widget::impl_widget_ext!(SimpleTerminal, Fl_Simple_Terminal);
 crate::macros::widget::impl_widget_base!(SimpleTerminal, Fl_Simple_Terminal);
 crate::macros::display::impl_display_ext!(SimpleTerminal, Fl_Simple_Terminal);
 
+/// The attribute of the style entry
+#[derive(Debug, Clone, Copy)]
+#[non_exhaustive]
+pub enum Attr {
+    /// Use the background color in the `bgcolor` field
+    BgColor = 0x0001,
+    /// Extend background color to the end of the line
+    BgColorExt = 0x0003,
+    /// A single underline, underline types are mutually exclusive
+    Underline = 0x0004,
+    /// Grammar suggestion (blue dotted underline)
+    Grammar = 0x0008,
+    /// Spelling suggestion (red dotted underline)
+    Spelling = 0x000C,
+    /// Line through the middle of the text
+    StrikeThrough = 0x0010,
+    /// The mask for all underline and strike through types
+    LinesMask = 0x001C,
+}
+
 /// Defines the styles used in the `set_highlight_data`, which is used with style buffers
 #[derive(Debug, Clone, Copy)]
 pub struct StyleTableEntry {
@@ -695,6 +715,21 @@ pub struct StyleTableEntry {
     pub font: Font,
     /// Font size
     pub size: i32,
+}
+
+/// Defines the styles used in the `set_highlight_data`, which is used with style buffers
+#[derive(Debug, Clone, Copy)]
+pub struct StyleTableEntryEx {
+    /// Font color
+    pub color: Color,
+    /// Font type
+    pub font: Font,
+    /// Font size
+    pub size: i32,
+    /// attribute
+    pub attr: Attr,
+    /// background color
+    pub bgcolor: Color,
 }
 
 impl TextEditor {

--- a/fltk/src/text.rs
+++ b/fltk/src/text.rs
@@ -688,12 +688,13 @@ crate::macros::display::impl_display_ext!(SimpleTerminal, Fl_Simple_Terminal);
 
 /// The attribute of the style entry
 #[derive(Debug, Clone, Copy)]
+#[repr(u32)]
 #[non_exhaustive]
 pub enum Attr {
+    /// No attribute
+    None = 0x0000,
     /// Use the background color in the `bgcolor` field
     BgColor = 0x0001,
-    /// Extend background color to the end of the line
-    BgColorExt = 0x0003,
     /// A single underline, underline types are mutually exclusive
     Underline = 0x0004,
     /// Grammar suggestion (blue dotted underline)
@@ -702,8 +703,6 @@ pub enum Attr {
     Spelling = 0x000C,
     /// Line through the middle of the text
     StrikeThrough = 0x0010,
-    /// The mask for all underline and strike through types
-    LinesMask = 0x001C,
 }
 
 /// Defines the styles used in the `set_highlight_data`, which is used with style buffers
@@ -719,7 +718,7 @@ pub struct StyleTableEntry {
 
 /// Defines the styles used in the `set_highlight_data`, which is used with style buffers
 #[derive(Debug, Clone, Copy)]
-pub struct StyleTableEntryEx {
+pub struct StyleTableEntryExt {
     /// Font color
     pub color: Color,
     /// Font type

--- a/fltk/src/text.rs
+++ b/fltk/src/text.rs
@@ -320,6 +320,69 @@ impl TextBuffer {
         unsafe { Fl_Text_Buffer_replace_selection(self.inner, text.as_ptr()) }
     }
 
+    /// Secondary selects the text from start to end
+    pub fn secondary_select(&mut self, start: i32, end: i32) {
+        assert!(!self.inner.is_null());
+        unsafe { Fl_Text_Buffer_secondary_select(self.inner, start as i32, end as i32) }
+    }
+
+    /// Returns whether text is secondary selected
+    pub fn secondary_selected(&self) -> bool {
+        assert!(!self.inner.is_null());
+        unsafe { Fl_Text_Buffer_secondary_selected(self.inner) != 0 }
+    }
+
+    /// Unselects text (secondary selection)
+    pub fn secondary_unselect(&mut self) {
+        assert!(!self.inner.is_null());
+        unsafe { Fl_Text_Buffer_secondary_unselect(self.inner) }
+    }
+
+    /// Returns the secondary selection position
+    pub fn secondary_selection_position(&self) -> Option<(i32, i32)> {
+        assert!(!self.inner.is_null());
+        unsafe {
+            let mut start = 0;
+            let mut end = 0;
+            let ret = Fl_Text_Buffer_secondary_selection_position(
+                self.inner,
+                &mut start as _,
+                &mut end as _,
+            );
+            if ret == 0 {
+                None
+            } else {
+                let x = (start as i32, end as i32);
+                Some(x)
+            }
+        }
+    }
+
+    /// Returns the secondary selection text
+    pub fn secondary_selection_text(&self) -> String {
+        assert!(!self.inner.is_null());
+        unsafe {
+            let x = Fl_Text_Buffer_secondary_selection_text(self.inner);
+            assert!(!x.is_null());
+            CStr::from_ptr(x as *mut raw::c_char)
+                .to_string_lossy()
+                .to_string()
+        }
+    }
+
+    /// Removes the secondary selection
+    pub fn remove_secondary_selection(&mut self) {
+        assert!(!self.inner.is_null());
+        unsafe { Fl_Text_Buffer_remove_secondary_selection(self.inner) }
+    }
+
+    /// Replaces the secondary selection
+    pub fn replace_secondary_selection(&mut self, text: &str) {
+        assert!(!self.inner.is_null());
+        let text = CString::safe_new(text);
+        unsafe { Fl_Text_Buffer_replace_secondary_selection(self.inner, text.as_ptr()) }
+    }
+
     /// Highlights selection
     pub fn highlight(&mut self, start: i32, end: i32) {
         assert!(!self.inner.is_null());

--- a/fltk/src/text.rs
+++ b/fltk/src/text.rs
@@ -695,6 +695,9 @@ pub struct StyleTableEntry {
 }
 
 impl TextEditor {
+    /// Any state/shortcut
+    pub const AnyState: crate::enums::Shortcut = crate::enums::Shortcut::from_i32(-1);
+
     /// Set to insert mode
     pub fn set_insert_mode(&mut self, b: bool) {
         assert!(!self.was_deleted());
@@ -945,6 +948,32 @@ impl TextEditor {
         assert!(self.buffer().is_some());
         unsafe {
             Fl_Text_Editor_kf_select_all(self.inner);
+        }
+    }
+
+    /// Add a key binding
+    pub fn add_key_binding(
+        &mut self,
+        key: crate::enums::Key,
+        shortcut: crate::enums::Shortcut,
+        cb: fn(key: crate::enums::Key, editor: *mut Fl_Text_Editor) -> i32,
+    ) {
+        assert!(!self.was_deleted());
+        unsafe {
+            Fl_Text_Editor_add_key_binding(
+                self.inner,
+                key.bits(),
+                shortcut.bits(),
+                std::mem::transmute(Some(cb)),
+            );
+        }
+    }
+
+    /// Remove a key binding
+    pub fn remove_key_binding(&mut self, key: crate::enums::Key, shortcut: crate::enums::Shortcut) {
+        assert!(!self.was_deleted());
+        unsafe {
+            Fl_Text_Editor_remove_key_binding(self.inner, key.bits(), shortcut.bits());
         }
     }
 }


### PR DESCRIPTION
- Add TextEditor::AnyState const value.
- Add TextEditor::add_key_binding() and remove_key_binding().
- Add TextBuffer methods of secondary selection.
- Fix for unicode fonts.
- Add DisplayExt::set_highlight_data_ext() and text::StyleTableEntryExt (supports underline, strikethrough, background color...etc).
- Add setters & getters for secondary selection, spelling and grammar colors.
- Pull FLTK menu fixes.
- Update FLTK (removes experimental drivers).