### PR TITLE
Free singleshot heap-allocated trait-object(callbacks) after calling cbs

### DIFF
--- a/fltk/src/app/rt.rs
+++ b/fltk/src/app/rt.rs
@@ -57,7 +57,7 @@ pub fn awake() {
 pub fn awake_callback<F: FnMut() + 'static>(cb: F) {
     unsafe {
         unsafe extern "C" fn shim(data: *mut raw::c_void) {
-            let a: *mut Box<dyn FnMut()> = data as *mut Box<dyn FnMut()>;
+            let mut a: Box<Box<dyn FnMut()>> = Box::from_raw(data as *mut Box<dyn FnMut()>);
             let f: &mut (dyn FnMut()) = &mut **a;
             let _ = panic::catch_unwind(panic::AssertUnwindSafe(f));
         }
@@ -372,7 +372,7 @@ pub fn add_timeout<F: FnMut() + 'static>(tm: f64, cb: F) {
     unsafe {
         assert!(crate::app::is_ui_thread());
         unsafe extern "C" fn shim(data: *mut raw::c_void) {
-            let a: *mut Box<dyn FnMut()> = data as *mut Box<dyn FnMut()>;
+            let mut a: Box<Box<dyn FnMut()>> = Box::from_raw(data as *mut Box<dyn FnMut()>);
             let f: &mut (dyn FnMut()) = &mut **a;
             let _ = panic::catch_unwind(panic::AssertUnwindSafe(f));
         }


### PR DESCRIPTION
Hi! Thanks for the great GUI lib with minimal overhead and dependencies!

I've skimmed through codebase and notice quite regular pattern for creating callbacks:
https://github.com/fltk-rs/fltk-rs/blob/master/fltk/src/app/rt.rs#L64

```let a: *mut Box<dyn FnMut()> = Box::into_raw(Box::new(Box::new(cb)));```

see https://doc.rust-lang.org/std/boxed/struct.Box.html#examples-23
After calling this function, the caller is responsible for the memory previously managed by the Box

In special cases with singleshot callbacks (awake_callback and add_timeout) heap allocations for trait-objects could be freed after calling callback.
Now as far as I understood (I have not much expirience with Rust and can't say I understand all the details of codebase) we got memleak on each call of awake_callback and add_timeout that could be easily fixed by this PR.

There is the example at https://github.com/mosolovsa/leakingcallback demonstrating behavior with and without proposed changes.

The set_callback for widget has no leaks because the mem is freed due to call Box:from_raw and constructing Box<Box<dyn FnMut>>>:
https://github.com/mosolovsa/fltk-rs/blob/master/fltk/src/macros/widget.rs#L551
outer box mem get freed and the inner box extracted to get free later when _old_data goes out of the scope at the end of function:
https://github.com/mosolovsa/fltk-rs/blob/master/fltk/src/macros/widget.rs#L805

I appologize for my communicational skills in English :)