### PR TITLE
1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ## [1.3.1] - Unreleased
 - Pull updated Wayland backend code from FLTK.
 - Fix HasRawWindowHandle implementation on Wayland.
+- Improve TreeItem::move* docs.
 
 ## [1.3.0] - 2022-03-06
 - Pull FLTK dialog [fix](https://github.com/fltk/fltk/issues/401).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-## [1.3.1] - Unreleased
+## [1.3.1] - 2022-03-22
 - Pull updated Wayland backend code from FLTK.
 - Fix HasRawWindowHandle implementation on Wayland.
 - Improve TreeItem::move* docs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix HasRawWindowHandle implementation on Wayland.
 - Improve TreeItem::move* docs.
 - Deprecate dialog::choice() and choice_default() in favor of choice2() and choice2_default().
+- Fix BrowserExt::set_icon() leak after calling BrowserExt::clear().
 
 ## [1.3.0] - 2022-03-06
 - Pull FLTK dialog [fix](https://github.com/fltk/fltk/issues/401).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Pull updated Wayland backend code from FLTK.
 - Fix HasRawWindowHandle implementation on Wayland.
 - Improve TreeItem::move* docs.
+- Deprecate dialog::choice() and choice_default() in favor of choice2() and choice2_default().
 
 ## [1.3.0] - 2022-03-06
 - Pull FLTK dialog [fix](https://github.com/fltk/fltk/issues/401).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 
+## [1.3.1] - Unreleased
+- Pull updated Wayland backend code from FLTK.
+- Fix HasRawWindowHandle implementation on Wayland.
+
 ## [1.3.0] - 2022-03-06
 - Pull FLTK dialog [fix](https://github.com/fltk/fltk/issues/401).
 - Pull FLTK's wayland support.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,3 +9,4 @@
 - FileChooser::directory() should return a PathBuf.
 - Rename timeout3 functions to timeout, as well as idle and clipboard callbacks.
 - Support opacity and platform_hide/platform_show for the wayland backend.
+- Rename no-pango feature to no-pango-cairo, to better reflect the linked libs.

--- a/fltk-sys/Cargo.toml
+++ b/fltk-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk-sys"
-version = "1.3.0"
+version = "1.3.1"
 authors = ["The fltk-rs Authors"]
 build = "build/main.rs"
 edition = "2018"

--- a/fltk/Cargo.toml
+++ b/fltk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk"
-version = "1.3.0"
+version = "1.3.1"
 authors = ["The fltk-rs Authors"]
 edition = "2018"
 description = "Rust bindings for the FLTK GUI library"
@@ -17,7 +17,7 @@ name = "fltk"
 path = "src/lib.rs"
 
 [dependencies]
-fltk-sys = { path = "../fltk-sys", version = "=1.3.0" }
+fltk-sys = { path = "../fltk-sys", version = "=1.3.1" }
 bitflags = "^1.3"
 paste = "1"
 crossbeam-channel = "0.5"

--- a/fltk/src/dialog.rs
+++ b/fltk/src/dialog.rs
@@ -251,8 +251,8 @@ pub fn alert(x: i32, y: i32, txt: &str) {
     }
 }
 
-/// Displays a choice box with up to three choices.
-/// An empty choice will not be shown
+#[deprecated(since = "1.3.1", note = "please use `choice2` instead")]
+/// Displays a choice box with up to three choices. Choosing a value returns its index from the arguments
 pub fn choice(x: i32, y: i32, txt: &str, b0: &str, b1: &str, b2: &str) -> i32 {
     unsafe {
         let txt = CString::safe_new(txt);
@@ -263,8 +263,8 @@ pub fn choice(x: i32, y: i32, txt: &str, b0: &str, b1: &str, b2: &str) -> i32 {
     }
 }
 
-/// Displays a choice box with up to three choices.
-/// An empty choice will not be shown. Closing the dialog returns None
+/// Displays a choice box with up to three choices. 
+/// Closing the dialog returns None. Choosing a value returns its index from the arguments.
 pub fn choice2(x: i32, y: i32, txt: &str, b0: &str, b1: &str, b2: &str) -> Option<i32> {
     unsafe {
         let txt = CString::safe_new(txt);
@@ -317,7 +317,7 @@ pub fn password(x: i32, y: i32, txt: &str, deflt: &str) -> Option<String> {
     }
 }
 
-/// Displays a message box
+/// Displays a message box, the dialog is positioned at the pointer hotspot
 pub fn message_default(txt: &str) {
     unsafe {
         let txt = CString::safe_new(txt);
@@ -325,7 +325,7 @@ pub fn message_default(txt: &str) {
     }
 }
 
-/// Displays an alert box
+/// Displays an alert box, the dialog is positioned at the pointer hotspot
 pub fn alert_default(txt: &str) {
     unsafe {
         let txt = CString::safe_new(txt);
@@ -333,8 +333,9 @@ pub fn alert_default(txt: &str) {
     }
 }
 
+#[deprecated(since = "1.3.1", note = "please use `choice2_default` instead")]
 /// Displays a choice box with up to three choices.
-/// An empty choice will not be shown
+/// The dialog is positioned at the pointer hotspot
 pub fn choice_default(txt: &str, b0: &str, b1: &str, b2: &str) -> i32 {
     unsafe {
         let txt = CString::safe_new(txt);
@@ -346,7 +347,8 @@ pub fn choice_default(txt: &str, b0: &str, b1: &str, b2: &str) -> i32 {
 }
 
 /// Displays a choice box with up to three choices.
-/// An empty choice will not be shown. Closing the dialog returns None
+/// An empty choice will not be shown. Closing the dialog returns None. Choosing a value returns its index from the arguments.
+/// The dialog is positioned at the pointer hotspot
 pub fn choice2_default(txt: &str, b0: &str, b1: &str, b2: &str) -> Option<i32> {
     unsafe {
         let txt = CString::safe_new(txt);
@@ -363,7 +365,8 @@ pub fn choice2_default(txt: &str, b0: &str, b1: &str, b2: &str) -> Option<i32> {
 }
 
 /// Displays an input box, which returns the inputted string.
-/// Can be used for gui io
+/// Can be used for gui io.
+/// The dialog is positioned at the pointer hotspot
 pub fn input_default(txt: &str, deflt: &str) -> Option<String> {
     unsafe {
         let temp = CString::safe_new(deflt);
@@ -381,7 +384,8 @@ pub fn input_default(txt: &str, deflt: &str) -> Option<String> {
     }
 }
 
-/// Shows an input box, but with hidden string
+/// Shows an input box, but with hidden string.
+/// The dialog is positioned at the pointer hotspot
 pub fn password_default(txt: &str, deflt: &str) -> Option<String> {
     unsafe {
         let temp = CString::safe_new(deflt);

--- a/fltk/src/macros/window.rs
+++ b/fltk/src/macros/window.rs
@@ -443,6 +443,7 @@ macro_rules! impl_window_ext {
                     assert!(!self.was_deleted());
                     assert!(self.is_derived);
                     if self.shown() {
+                        self.wait_for_expose();
                         let val: u8 = if val > 1.0 {
                             255
                         } else if val < 0.0 {

--- a/fltk/src/tree.rs
+++ b/fltk/src/tree.rs
@@ -1629,7 +1629,7 @@ impl TreeItem {
         }
     }
 
-    /// Move item
+    /// Move the item 'from' to sibling position of 'to'.
     /// # Errors
     /// Errors on failure to move item   
     pub fn move_item(&mut self, to: i32, from: i32) -> Result<(), FltkError> {
@@ -1642,7 +1642,7 @@ impl TreeItem {
         }
     }
 
-    /// Move item above another item
+    /// Move the current item above the specified `item`
     /// # Errors
     /// Errors on failure to move item   
     pub fn move_above(&mut self, item: &TreeItem) -> Result<(), FltkError> {
@@ -1655,7 +1655,7 @@ impl TreeItem {
         }
     }
 
-    /// Move item below another item
+    /// Move the current item below the specified `item`
     /// # Errors
     /// Errors on failure to move item   
     pub fn move_below(&mut self, item: &TreeItem) -> Result<(), FltkError> {
@@ -1668,7 +1668,7 @@ impl TreeItem {
         }
     }
 
-    /// Move item into another item
+    /// Parent the current item as a child of the specified `item`.
     /// # Errors
     /// Errors on failure to move item    
     pub fn move_into(&mut self, item: &TreeItem, pos: i32) -> Result<(), FltkError> {

--- a/fltk/src/window.rs
+++ b/fltk/src/window.rs
@@ -418,6 +418,10 @@ impl DoubleWindow {
                 XMapWindow(crate::app::display() as _, self.raw_handle() as _);
                 crate::app::flush();
             }
+            #[cfg(feature = "use-wayland")]
+            {
+                Fl_Double_Window_show(self.inner);
+            }
         }
     }
 
@@ -447,6 +451,14 @@ impl DoubleWindow {
                 }
                 XUnmapWindow(crate::app::display() as _, self.raw_handle() as _);
                 crate::app::flush();
+            }
+            #[cfg(feature = "use-wayland")]
+            {
+                extern "C" {
+                    fn wl_proxy_marshal(proxy: *mut raw::c_void, opcode: u32, ...);
+                }
+                wl_proxy_marshal(self.raw_handle() as _, 1, std::ptr::null_mut() as *mut raw::c_void, 0, 0); // attach
+                wl_proxy_marshal(self.raw_handle() as _, 6); // commit
             }
         }
     }


### PR DESCRIPTION
- Pull updated Wayland backend code from FLTK.
- Fix HasRawWindowHandle implementation on Wayland.
- Improve TreeItem::move* docs.
- Deprecate dialog::choice() and choice_default() in favor of choice2() and choice2_default().
- Fix BrowserExt::set_icon() leak after calling BrowserExt::clear().