### PR TITLE
Unify `Coordinates`, `Cell` & `Size` to `Pair` aliases

### DIFF
--- a/fltk/examples/screens_info.rs
+++ b/fltk/examples/screens_info.rs
@@ -1,8 +1,7 @@
 use fltk::{
     app::Screen,
-    draw::{Coordinates, Rect},
+    draw::{Xy, Rect},
 };
-type Coord = Coordinates<i32>;
 
 fn main() {
     let screens = Screen::all_screens();
@@ -13,11 +12,11 @@ fn main() {
     println!("- at all = {}", Screen::scaling_supported());
     println!("- separately = {}", Screen::scaling_supported_separately());
 
-    let coord: Coord = [100, 100].into();
+    let coord: Xy = [100, 100].into();
     let rect: Rect = [100, 100, 100, 100].into();
 
     // uncomment these lines to see out-of-boundaries errors:
-    // let coord: Coord = [-100, 10_000].into();
+    // let coord: Xy = [-100, 10_000].into();
     // let rect: Rect = [-100, 100, 10_000, 10_000].into();
 
     println!("\nScreen found:");

--- a/fltk/src/app/screen.rs
+++ b/fltk/src/app/screen.rs
@@ -3,10 +3,9 @@
 use fltk_sys::fl;
 
 use crate::{
-    draw::{Coordinates, Rect},
+    draw::{Xy, Rect},
     prelude::{FltkError, FltkErrorKind},
 };
-type Coord = Coordinates<i32>; // TEMP
 
 /// An available screen
 ///
@@ -45,11 +44,11 @@ impl Screen {
     /// Returns the `Screen` that contains the specified screen position
     ///
     /// Returns an error if the provided coordinates are out of bounds.
-    pub fn new_at<C: Into<Coord> + Copy>(pos: C) -> Result<Screen, FltkError> {
-        let pos: Coord = pos.into();
+    pub fn new_at<C: Into<Xy> + Copy>(pos: C) -> Result<Screen, FltkError> {
+        let pos: Xy = pos.into();
 
         let s = Screen {
-            n: unsafe { fl::Fl_screen_num(pos.x, pos.y) },
+            n: unsafe { fl::Fl_screen_num(pos.x(), pos.y()) },
         };
 
         if Self::is_coord_inside_any_work_area(pos) {
@@ -97,10 +96,10 @@ impl Screen {
     /// the specified screen position coordinates
     ///
     /// Returns an error if the provided coordinates are out of bounds.
-    pub fn num_at<C: Into<Coord> + Copy>(pos: C) -> Result<i32, FltkError> {
-        let pos: Coord = pos.into();
+    pub fn num_at<C: Into<Xy> + Copy>(pos: C) -> Result<i32, FltkError> {
+        let pos: Xy = pos.into();
         if Self::is_coord_inside_any_work_area(pos) {
-            Ok(unsafe { fl::Fl_screen_num(pos.x, pos.y) })
+            Ok(unsafe { fl::Fl_screen_num(pos.x(), pos.y()) })
         } else {
             Err(FltkError::Internal(FltkErrorKind::ResourceNotFound))
         }
@@ -110,11 +109,11 @@ impl Screen {
     /// contains the specified screen position coordinates
     ///
     /// Returns an error if the provided coordinates are out of bounds.
-    pub fn work_area_at<C: Into<Coord> + Copy>(pos: C) -> Result<Rect, FltkError> {
-        let pos: Coord = pos.into();
+    pub fn work_area_at<C: Into<Xy> + Copy>(pos: C) -> Result<Rect, FltkError> {
+        let pos: Xy = pos.into();
         if Self::is_coord_inside_any_work_area(pos) {
             let (mut x, mut y, mut w, mut h) = (0, 0, 0, 0);
-            unsafe { fl::Fl_screen_work_area_at(&mut x, &mut y, &mut w, &mut h, pos.x, pos.y) }
+            unsafe { fl::Fl_screen_work_area_at(&mut x, &mut y, &mut w, &mut h, pos.x(), pos.y()) }
             Ok(Rect { x, y, w, h })
         } else {
             Err(FltkError::Internal(FltkErrorKind::ResourceNotFound))
@@ -148,11 +147,11 @@ impl Screen {
     /// contains the specified screen position coordinates
     ///
     /// Returns an error if the provided coordinates are out of bounds.
-    pub fn xywh_at<C: Into<Coord> + Copy>(pos: C) -> Result<Rect, FltkError> {
-        let pos: Coord = pos.into();
+    pub fn xywh_at<C: Into<Xy> + Copy>(pos: C) -> Result<Rect, FltkError> {
+        let pos: Xy = pos.into();
         if Self::is_coord_inside_any_xywh(pos) {
             let (mut x, mut y, mut w, mut h) = (0, 0, 0, 0);
-            unsafe { fl::Fl_screen_xywh_at(&mut x, &mut y, &mut w, &mut h, pos.x, pos.y) }
+            unsafe { fl::Fl_screen_xywh_at(&mut x, &mut y, &mut w, &mut h, pos.x(), pos.y()) }
             Ok(Rect { x, y, w, h })
         } else {
             Err(FltkError::Internal(FltkErrorKind::ResourceNotFound))
@@ -270,12 +269,12 @@ impl Screen {
     }
 
     /// Returns the top-left `x,y` coordinates of the current screen's work area
-    pub fn top_left(&self) -> Coord {
+    pub fn top_left(&self) -> Xy {
         self.work_area().top_left()
     }
 
     /// Returns the bottom-right `x+w, y+h` coordinates of the current screen's work area
-    pub fn bottom_right(&self) -> Coord {
+    pub fn bottom_right(&self) -> Xy {
         self.work_area().bottom_right()
     }
 
@@ -283,15 +282,15 @@ impl Screen {
 
     // returns `true` if the provided position is inside the bounds
     // of any current work area boundaries, or `false` otherwise.
-    fn is_coord_inside_any_work_area<C: Into<Coord> + Copy>(c: C) -> bool {
-        let c: Coord = c.into();
+    fn is_coord_inside_any_work_area<C: Into<Xy> + Copy>(c: C) -> bool {
+        let c: Xy = c.into();
         let main_wa: Rect = screen_work_area(0).into();
         // returns false if we get `0` but the coords are outside main screen's
-        !(screen_num(c.x, c.y) == 0
-            && (c.x < main_wa.x
-                || c.y < main_wa.y
-                || c.x >= main_wa.bottom_right().x
-                || c.y >= main_wa.bottom_right().y))
+        !(screen_num(c.x(), c.y()) == 0
+            && (c.x() < main_wa.x
+                || c.y() < main_wa.y
+                || c.x() >= main_wa.bottom_right().x()
+                || c.y() >= main_wa.bottom_right().y()))
     }
     // returns `true` if the provided rect is fully inside the bounds
     // of any current work area boundaries, or `false` otherwise.
@@ -303,15 +302,15 @@ impl Screen {
 
     // returns `true` if the provided position is inside the bounds
     // of any current screen xywh boundaries, or `false` otherwise.
-    fn is_coord_inside_any_xywh<C: Into<Coord> + Copy>(c: C) -> bool {
-        let c: Coord = c.into();
+    fn is_coord_inside_any_xywh<C: Into<Xy> + Copy>(c: C) -> bool {
+        let c: Xy = c.into();
         let main_xywh: Rect = screen_xywh(0).into();
         // returns false if we get `0` but the coords are outside main screen's
-        !(screen_num(c.x, c.y) == 0
-            && (c.x < main_xywh.x
-                || c.y < main_xywh.y
-                || c.x >= main_xywh.bottom_right().x
-                || c.y >= main_xywh.bottom_right().y))
+        !(screen_num(c.x(), c.y()) == 0
+            && (c.x() < main_xywh.x
+                || c.y() < main_xywh.y
+                || c.x() >= main_xywh.bottom_right().x()
+                || c.y() >= main_xywh.bottom_right().y()))
     }
     // returns `true` if the provided rect is fully inside the bounds
     // of any current screeen xywh boundaries, or `false` otherwise.

--- a/fltk/src/draw/mod.rs
+++ b/fltk/src/draw/mod.rs
@@ -8,7 +8,7 @@ use std::mem;
 use std::os::raw;
 
 mod types;
-pub use types::{Coord, Coord_f64, Coordinates, Rect, Rectangle};
+pub use types::{Coord, Pair, Rect, Rectangle, Size, Xy};
 
 bitflags::bitflags! {
     /// Defines the line styles supported by fltk

--- a/fltk/src/draw/types.rs
+++ b/fltk/src/draw/types.rs
@@ -1,172 +1,152 @@
-/// Defines a pair of `x, y` coordinates
+use std::ops::{Add, Sub};
+
+/// Defines a pair of two comparable values
 #[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub struct Coordinates<T: Copy> {
-    /// Horizontal X coordinate
-    pub x: T,
-    /// Vertical Y coordinate
-    pub y: T,
+pub struct Pair<T: Copy>(pub T, pub T);
+
+/// Coordinates
+#[derive(Debug, Copy, Clone)]
+pub struct Coord<T: Copy>(pub T, pub T); // TODO deprecate for 2.0
+
+/// A pair of `(row, col)` coordinates representing a cell
+pub type Cell = Pair<i32>;
+
+impl Cell {
+    /// New pair of `(row, col)` coordinates
+    pub fn new_cell(row: i32, col: i32) -> Self {
+        Self(col, row)
+    }
+    /// The column
+    pub fn col(&self) -> i32 {
+        self.0
+    }
+    /// The row
+    pub fn row(&self) -> i32 {
+        self.1
+    }
+    /// Set the column
+    pub fn set_col(&mut self, col: i32) {
+        self.0 = col
+    }
+    /// Set the row
+    pub fn set_row(&mut self, row: i32) {
+        self.1 = row
+    }
 }
 
-/// `i32` Coordinates
-#[derive(Debug, Copy, Clone)]
-pub struct Coord<T: Copy>(pub T, pub T);
-// pub type Coord = Coordinates<i32>; // TODO for 2.0
+/// A pair of `(x, y)` coordinates representing a pixel
+pub type Xy = Pair<i32>;
 
-/// `f64` Coordinates
-#[allow(non_camel_case_types)]
-pub type Coord_f64 = Coordinates<f64>;
+// TODO: rename to Coord for 2.0
+impl Xy {
+    /// New pair of `(x, y)` coordinates
+    pub fn new_xy(x: i32, y: i32) -> Self {
+        Self(x, y)
+    }
+    /// The `x` coordinate
+    pub fn x(&self) -> i32 {
+        self.0
+    }
+    /// The `y` coordinate
+    pub fn y(&self) -> i32 {
+        self.1
+    }
+    /// Set `x`
+    pub fn set_x(&mut self, x: i32) {
+        self.0 = x
+    }
+    /// Set `y`
+    pub fn set_y(&mut self, y: i32) {
+        self.1 = y
+    }
+}
 
-impl<T: Copy> Coordinates<T> {
-    /// Returns a new pair of `x, y` coordinates
+/// A pair of (width, heigth) sizes
+pub type Size = Pair<i32>;
+
+impl Size {
+    /// New pair of `(width, height)` coordinates
+    pub fn new_size(width: i32, height: i32) -> Self {
+        Self(width, height)
+    }
+    /// The width
+    pub const fn w(&self) -> i32 {
+        self.0
+    }
+    /// The height
+    pub const fn h(&self) -> i32 {
+        self.1
+    }
+    /// The width
+    pub const fn width(&self) -> i32 {
+        self.0
+    }
+    /// The height
+    pub const fn height(&self) -> i32 {
+        self.1
+    }
+    /// Set the width
+    pub fn set_w(&mut self, width: i32) {
+        self.0 = width
+    }
+    /// Set the height
+    pub fn set_h(&mut self, height: i32) {
+        self.1 = height
+    }
+    /// Set the width
+    pub fn set_width(&mut self, width: i32) {
+        self.0 = width
+    }
+    /// Set the height
+    pub fn set_height(&mut self, height: i32) {
+        self.1 = height
+    }
+}
+
+// /// Xy `f64` Coordinates
+// pub type XyF64 = Pair<f64>;
+
+impl<T: Copy> Pair<T> {
+    /// New coordinate pair
     pub fn new(x: T, y: T) -> Self {
-        Coordinates { x, y }
+        Self(x, y)
     }
 
     /// Returns a tuple of the values
     pub fn tup(&self) -> (T, T) {
-        (self.x, self.y)
+        (self.0, self.1)
     }
 }
 
-// Conversions From/Into array and tuple
+// impl From/Into array and tuple for Pair
 
-impl<T: Copy> From<[T; 2]> for Coordinates<T> {
+impl<T: Copy> From<[T; 2]> for Pair<T> {
     fn from(array: [T; 2]) -> Self {
-        Self {
-            x: array[0],
-            y: array[1],
-        }
+        Self(array[0], array[1])
     }
 }
 
-impl<T: Copy> From<Coordinates<T>> for [T; 2] {
-    fn from(c: Coordinates<T>) -> Self {
-        [c.x, c.y]
+impl<T: Copy> From<Pair<T>> for [T; 2] {
+    fn from(c: Pair<T>) -> Self {
+        [c.0, c.1]
     }
 }
 
-impl<T: Copy> From<(T, T)> for Coordinates<T> {
+impl<T: Copy> From<(T, T)> for Pair<T> {
     fn from(tuple: (T, T)) -> Self {
-        Self {
-            x: tuple.0,
-            y: tuple.1,
-        }
+        Self(tuple.0, tuple.1)
     }
 }
 
-impl<T: Copy> From<Coordinates<T>> for (T, T) {
-    fn from(c: Coordinates<T>) -> Self {
-        (c.x, c.y)
+impl<T: Copy> From<Pair<T>> for (T, T) {
+    fn from(c: Pair<T>) -> Self {
+        (c.0, c.1)
     }
 }
-
-/// Defines a pair of `w, h` (width, height) values representing size
-#[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub struct Size {
-    /// Width
-    pub w: i32,
-    /// Height
-    pub h: i32,
-}
-
-impl Size {
-    /// Returns a new pair of `w, h` (width, height) values
-    pub fn new(w: i32, h: i32) -> Self {
-        Size { w, h }
-    }
-
-    /// Returns a tuple of the values
-    pub fn tup(&self) -> (i32, i32) {
-        (self.w, self.h)
-    }
-}
-
-// Conversions From/Into array and tuple
-
-impl From<[i32; 2]> for Size {
-    fn from(array: [i32; 2]) -> Self {
-        Self {
-            w: array[0],
-            h: array[1],
-        }
-    }
-}
-
-impl From<Size> for [i32; 2] {
-    fn from(c: Size) -> Self {
-        [c.w, c.h]
-    }
-}
-
-impl From<(i32, i32)> for Size {
-    fn from(tuple: (i32, i32)) -> Self {
-        Self {
-            w: tuple.0,
-            h: tuple.1,
-        }
-    }
-}
-impl From<Size> for (i32, i32) {
-    fn from(c: Size) -> Self {
-        (c.w, c.h)
-    }
-}
-
-/// Defines a pair of `r, c` (row, column) representing a Cell
-#[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub struct Cell {
-    /// Horizontal X coordinate
-    pub r: i32,
-    /// Vertical Y coordinate
-    pub c: i32,
-}
-
-impl Cell {
-    /// Returns a new pair of `r, c` (row, column) cell
-    pub fn new(r: i32, c: i32) -> Self {
-        Cell { r, c }
-    }
-
-    /// Returns a tuple of the values
-    pub fn tup(&self) -> (i32, i32) {
-        (self.r, self.c)
-    }
-}
-
-// Conversions From/Into array and tuple
-
-impl From<[i32; 2]> for Cell {
-    fn from(array: [i32; 2]) -> Self {
-        Cell {
-            r: array[0],
-            c: array[1],
-        }
-    }
-}
-
-impl From<Cell> for [i32; 2] {
-    fn from(c: Cell) -> Self {
-        [c.r, c.c]
-    }
-}
-
-impl From<(i32, i32)> for Cell {
-    fn from(tuple: (i32, i32)) -> Self {
-        Self {
-            r: tuple.0,
-            c: tuple.1,
-        }
-    }
-}
-impl From<Cell> for (i32, i32) {
-    fn from(c: Cell) -> Self {
-        (c.r, c.c)
-    }
-}
-
-use std::ops::{Add, Sub};
 
 /// Defines a rectangular bounding box
+//
+// MAYBE generalize like Pair, rename to Quadruple tuple
 #[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct Rectangle<T: Copy + Add<Output = T> + Sub<Output = T>> {
     /// Leftmost corner
@@ -179,7 +159,7 @@ pub struct Rectangle<T: Copy + Add<Output = T> + Sub<Output = T>> {
     pub h: T,
 }
 
-/// `i32` Coordinates
+/// `i32` Rectangle
 pub type Rect = Rectangle<i32>;
 
 impl<T: Copy + Add<Output = T> + Sub<Output = T>> Rectangle<T> {
@@ -196,23 +176,23 @@ impl<T: Copy + Add<Output = T> + Sub<Output = T>> Rectangle<T> {
 
     /// Returns a new `Rectangle` from the position of its `top_left`
     /// and `bottom_right` corners.
-    pub fn from_coords(top_left: Coordinates<T>, bottom_right: Coordinates<T>) -> Self {
+    pub fn from_pairs(top_left: Pair<T>, bottom_right: Pair<T>) -> Self {
         Self {
-            x: top_left.x,
-            y: top_left.y,
-            w: bottom_right.x - top_left.x,
-            h: bottom_right.y - top_left.y,
+            x: top_left.0,
+            y: top_left.1,
+            w: bottom_right.0 - top_left.0,
+            h: bottom_right.1 - top_left.1,
         }
     }
 
     /// Returns the coordinates of the top-left corner
-    pub fn top_left(&self) -> Coordinates<T> {
-        Coordinates::new(self.x, self.y)
+    pub fn top_left(&self) -> Pair<T> {
+        Pair::new(self.x, self.y)
     }
 
     /// Returns the coordinates of the bottom-right corner
-    pub fn bottom_right(&self) -> Coordinates<T> {
-        Coordinates::new(self.x + self.w, self.y + self.h)
+    pub fn bottom_right(&self) -> Pair<T> {
+        Pair::new(self.x + self.w, self.y + self.h)
     }
 
     /// Returns a tuple of the values
@@ -221,7 +201,7 @@ impl<T: Copy + Add<Output = T> + Sub<Output = T>> Rectangle<T> {
     }
 }
 
-// Conversions From/Into array and tuple
+// impl From/Into array and tuple for Rectangle
 
 impl<T: Copy + Add<Output = T> + Sub<Output = T>> From<[T; 4]> for Rectangle<T> {
     fn from(array: [T; 4]) -> Self {


### PR DESCRIPTION
This is a proposal to refactor the new `Coordinates`, `Cell` and `Size` types as types aliases of a single generic `Pair` type with appropriately named get/set methods. (The same principle could be extended for the `Rectangle` type).

Coordinates temporarily named `Xy` should probably be renamed to `Coord` for 2.0, replacing all previous instances of `Coord`.