### PR TITLE
Check curl and tar exit code when downloading bundled fltk

### DIFF
--- a/fltk-sys/build/bundled.rs
+++ b/fltk-sys/build/bundled.rs
@@ -30,7 +30,7 @@ pub fn get(target_os: &str, out_dir: &Path) {
         };
 
         let curl_status = Command::new("curl")
-            .args(&["-LOk", url.to_str().unwrap()])
+            .args(&["-LOkf", url.to_str().unwrap()])
             .current_dir(out_dir)
             .status()
             .expect("Curl is needed to download the bundled libraries!");

--- a/fltk-sys/build/bundled.rs
+++ b/fltk-sys/build/bundled.rs
@@ -23,21 +23,30 @@ pub fn get(target_os: &str, out_dir: &Path) {
             }
 
             PathBuf::from(format!(
-                "https://github.com/fltk-rs/fltk-rs/releases/download/{}/lib_x64-{}.tar.gz",
+                "{}/{}/lib_x64-{}.tar.gz",
+                env::var("CFLTK_BUNDLE_URL_PREFIX").unwrap_or(String::from("https://github.com/fltk-rs/fltk-rs/releases/download")),
                 pkg_version, platform
             ))
         };
 
-        Command::new("curl")
+        let curl_status = Command::new("curl")
             .args(&["-LOk", url.to_str().unwrap()])
             .current_dir(out_dir)
             .status()
-            .expect("Curl and Tar are needed to download and upack the bundled libraries!");
+            .expect("Curl is needed to download the bundled libraries!");
 
-        Command::new("tar")
+        if ! curl_status.success() {
+            panic!("Download bundled libraries from {:?} failed", url)
+        }
+
+        let tar_status = Command::new("tar")
             .args(&["-xzvf", url.file_name().unwrap().to_str().unwrap()])
             .current_dir(out_dir)
             .status()
-            .expect("Curl and Tar are needed to download and upack the bundled libraries!");
+            .expect("Tar is needed to upack the bundled libraries!");
+
+        if ! tar_status.success() {
+            panic!("Unpack bundled libraries failed")
+        }
     }
 }


### PR DESCRIPTION
# Description

When using the `fltk-bundled`  feature, fltk-sys will download a prepackaged file from github using curl.

Sometimes connection to Github might not be stable: curl may take long time to finish, download part of the file or just download some error page, then tar will fail. I was getting weird errors which would fix themselves by rebuilding dependencies.

The problem is that the commands curl and tar are not checked for exit errors.

This patch checks the exit status of the tar and curl commands (curl needs a new 'f' flag to exit with non zero exit code on http error) and the build will fail.

Now when the download fails we get some error like this:
```
  curl: (22) The requested URL returned error: 404
  thread 'main' panicked at 'Download bundled libraries from "https://...
```

And when tar fails we might get some error like this:
```
  tar.exe: Error opening archive: Unrecognized archive format
  thread 'main' panicked at 'Unpack bundled libraries failed',
```

Also this patch adds the possibility to use a mirror service to download the prepackaged files using the environment variable CFLTK_BUNDLE_URL_PREFIX. The difference with CFLTK_BUNDLE_URL is that the download version is selected automatically using the new method and don't need to change the url when the fltk library is updated  or when switching between toolchains.

Example on using the new env var: create a `.cargo/config.toml` like this and will download from the new server:
```
[env]
CFLTK_BUNDLE_URL_PREFIX = "https://my.github.mirror/fltk-rs/fltk-rs/releases/download"
``` 
