### PR TITLE
require &Font instead of Font

### DIFF
--- a/fltk/examples/defaults.rs
+++ b/fltk/examples/defaults.rs
@@ -8,7 +8,7 @@ fn main() {
     // global theming
     app::background(r, g, b); // background color. For input/output and text widgets, use app::background2
     app::foreground(20, 20, 20); // labels
-    app::set_font(enums::Font::Courier);
+    app::set_font(&enums::Font::Courier);
     app::set_font_size(16);
     app::set_frame_type(enums::FrameType::RFlatBox);
     app::set_visible_focus(false);

--- a/fltk/src/app/font.rs
+++ b/fltk/src/app/font.rs
@@ -11,7 +11,7 @@ use std::{
 };
 
 /// Set the app's font
-pub fn set_font(new_font: Font) {
+pub fn set_font(new_font: &Font) {
     unsafe {
         let new_font = new_font.bits() as i32;
         let f = CURRENT_FONT.load(Ordering::Relaxed);
@@ -33,7 +33,7 @@ pub fn font_size() -> i32 {
 }
 
 /// Get the font's name
-pub fn get_font(font: Font) -> String {
+pub fn get_font(font: &Font) -> String {
     unsafe {
         CStr::from_ptr(fl::Fl_get_font(font.bits() as i32))
             .to_string_lossy()
@@ -42,7 +42,7 @@ pub fn get_font(font: Font) -> String {
 }
 
 /// Get the font's name
-pub fn get_font_name(font: Font) -> String {
+pub fn get_font_name(font: &Font) -> String {
     unsafe {
         CStr::from_ptr(fl::Fl_get_font_name(font.bits() as i32))
             .to_string_lossy()
@@ -51,7 +51,7 @@ pub fn get_font_name(font: Font) -> String {
 }
 
 /// Get a font's sizes
-pub fn get_font_sizes(font: Font) -> Vec<i32> {
+pub fn get_font_sizes(font: &Font) -> Vec<i32> {
     unsafe {
         let start = vec![0i32; 128];
         let mut start = std::mem::ManuallyDrop::new(start);


### PR DESCRIPTION
Several functions requiring ownership of `Font` only really need a `&Font` reference.