### PR TITLE
1.3.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 
+## [1.3.10] - 2022-07-10
+- Add WindowType::Single as alias to WindowType::Normal.
+- Add Window::set_on_top() which modifies the Window's level on macOS platforms to be NSMainMenuWindowLevel + 2.
+- Fix Flex::recalc to not change the current group.
+- Expose Group::set_current.
+- Pull FLTK fixes.
+
 ## [1.3.10] - 2022-07-01
 - Fix Flex::clear.
 - Fix build using musl on Alpine Linux. 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -13,3 +13,4 @@
 - app::screen_size() should return (i32, i32) since the implementation changed.
 - Refactor drawing code to use Coord and Rect.
 - Rust 1.63 constifies Mutex::new, so lazy_static can be removed.
+- Replace WindowType::Normal with WindowType::Single.

--- a/fltk/src/group.rs
+++ b/fltk/src/group.rs
@@ -463,6 +463,12 @@ impl Flex {
         self.recalc();
     }
 
+    /// Add a widget to the Flex box
+    pub fn insert<W: WidgetExt>(&mut self, widget: &W, idx: i32) {
+        <Self as GroupExt>::insert(self, widget, idx);
+        self.recalc();
+    }
+
     /// Set the size of the widget
     pub fn set_size<W: WidgetExt>(&mut self, w: &W, size: i32) {
         unsafe { Fl_Flex_set_size(self.inner, w.as_widget_ptr() as _, size) }
@@ -488,6 +494,7 @@ impl Flex {
     /// Recalculate children's coords and sizes
     pub fn recalc(&self) {
         self.end();
+        Group::set_current(None::<&Group>);
     }
 
     /// Set the margin

--- a/fltk/src/group.rs
+++ b/fltk/src/group.rs
@@ -42,6 +42,17 @@ impl Group {
             }
         }
     }
+
+    /// Sets the current GroupExt widget which will take children
+    pub fn set_current(grp: Option<&impl GroupExt>) {
+        unsafe {
+            if let Some(grp) = grp {
+                Fl_Group_set_current(grp.as_widget_ptr() as _)
+            } else {
+                Fl_Group_set_current(std::ptr::null_mut())
+            }
+        }
+    }
 }
 
 /// Creates a widget pack

--- a/fltk/src/group.rs
+++ b/fltk/src/group.rs
@@ -493,8 +493,8 @@ impl Flex {
 
     /// Recalculate children's coords and sizes
     pub fn recalc(&self) {
-        self.end();
-        Group::set_current(None::<&Group>);
+        let mut s = self.clone();
+        s.resize(self.x(), self.y(), self.w(), self.h());
     }
 
     /// Set the margin

--- a/fltk/src/window.rs
+++ b/fltk/src/window.rs
@@ -248,6 +248,20 @@ impl SingleWindow {
         let s = CString::safe_new(s);
         unsafe { Fl_Single_Window_set_default_xclass(s.as_ptr()) }
     }
+
+    /// Set the borderless window to be on top of the macos system menu bar
+    pub fn set_on_top(&self) {
+        #[cfg(target_os = "macos")]
+        {
+            extern "C" {
+                pub fn cfltk_setOnTop(handle: *mut raw::c_void);
+            }
+            assert!(self.border());
+            unsafe {
+                cfltk_setOnTop(self.raw_handle());
+            }
+        }
+    }
 }
 
 /// Creates a double (buffered) window widget
@@ -495,6 +509,18 @@ impl DoubleWindow {
     pub fn set_default_xclass(s: &str) {
         let s = CString::safe_new(s);
         unsafe { Fl_Double_Window_set_default_xclass(s.as_ptr()) }
+    }
+
+    #[cfg(target_os = "macos")]
+    /// Set the borderless window to be on top of the macos system menu bar
+    pub fn set_on_top(&mut self) {
+        assert!(!self.border());
+        extern "C" {
+            pub fn cfltk_setOnTop(handle: *mut raw::c_void);
+        }
+        unsafe {
+            cfltk_setOnTop(self.raw_handle());
+        }
     }
 }
 

--- a/fltk/src/window.rs
+++ b/fltk/src/window.rs
@@ -94,6 +94,11 @@ pub enum WindowType {
     Double = 241,
 }
 
+impl WindowType {
+    /// An alias for WindowType::Normal
+    pub const Single: WindowType = WindowType::Normal;
+}
+
 crate::macros::widget::impl_widget_type!(WindowType);
 
 /// Creates a single (buffered) window widget


### PR DESCRIPTION
- Add WindowType::Single as alias to WindowType::Normal.
- Add Window::set_on_top() which modifies the Window's level on macOS platforms to be NSMainMenuWindowLevel + 2.
- Fix Flex::recalc to not change the current group.
- Expose Group::set_current.
- Pull FLTK fixes.