### PR TITLE
Update text.rs

### DIFF
--- a/fltk/src/text.rs
+++ b/fltk/src/text.rs
@@ -33,9 +33,9 @@ pub struct TextBuffer {
     refcount: AtomicUsize,
 }
 
-impl TextBuffer {
+impl std::default::Default for TextBuffer {
     /// Initialized a default text buffer
-    pub fn default() -> TextBuffer {
+    fn default() -> TextBuffer {
         unsafe {
             let text_buffer = Fl_Text_Buffer_new();
             assert!(!text_buffer.is_null());
@@ -45,7 +45,9 @@ impl TextBuffer {
             }
         }
     }
+}
 
+impl TextBuffer {
     /// Deletes the `TextBuffer`
     /// # Safety
     /// The buffer shouldn't be deleted while the Display widget still needs it


### PR DESCRIPTION
Without this change, you cannot use #[derive(Default)] with a structure containing a TextBuffer 
