### PR TITLE
1.3.14 (#1283)

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v2
       - name: Install deps
-        run: sudo apt-get update && sudo apt-get install -y libpango1.0-dev libx11-dev libxext-dev libxft-dev libxinerama-dev libxcursor-dev libxrender-dev libxfixes-dev libpng-dev libgl1-mesa-dev libglu1-mesa-dev
+        run: git submodule update --init --recursive && sudo apt-get update && sudo apt-get install -y libpango1.0-dev libx11-dev libxext-dev libxft-dev libxinerama-dev libxcursor-dev libxrender-dev libxfixes-dev libpng-dev libgl1-mesa-dev libglu1-mesa-dev
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: seanmiddleditch/gha-setup-ninja@master
     - name: Build
-      run: cd fltk && cargo build --release --features=use-ninja && cd ..
+      run: git submodule update --init --recursive && cd fltk && cargo build --release --features=use-ninja && cd ..
       shell: bash
     - name: Upload a Build Artifact
       uses: actions/upload-artifact@v2

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,4 +25,4 @@ jobs:
     - uses: seanmiddleditch/gha-setup-ninja@master
     - name: Build
       shell: bash
-      run: cargo build --examples --verbose --features=use-ninja
+      run: git submodule update --init --recursive && cargo build --examples --verbose --features=use-ninja

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
 
+## [1.3.14] - 2022-09-06
+- impl std::default::Default for TextBuffer by @ConsoleC137.
+- Avoid calling git submodule update in build script.
+- Make ttf-parser an optional dependency.
+- Update raw-window-handle dep to 0.5.
+- Pull FLTK's hybrid wayland backend.
+- Pull FLTK fixes.
+
 ## [1.3.13] - 2022-08-09
 - Add BrowserExt::hide_line().
 - Replace lazy_static with once_cell.

--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ The following are the features offered by the crate:
 - system-libpng: Uses the system libpng
 - system-libjpeg: Uses the system libjpeg
 - system-zlib: Uses the system zlib
-- use-wayland: Uses FLTK's wayland backend. Requires libwayland-dev, wayland-protocols, libdbus-1-dev, libxkbcommon-dev, libgtk-3-dev (optional, for the GTK-style titlebar), in place of the X11 development packages. Sample [CI](https://github.com/MoAlyousef/test_wayland/blob/main/.github/workflows/rust.yml).
+- use-wayland: Uses FLTK's wayland hybrid backend (runs on wayland when present, and on X11 when not present). Requires libwayland-dev, wayland-protocols, libdbus-1-dev, libxkbcommon-dev, libgtk-3-dev (optional, for the GTK-style titlebar), in addition to the X11 development packages. Sample [CI](https://github.com/MoAlyousef/test_wayland/blob/main/.github/workflows/rust.yml).
 
 ## FAQ
 
@@ -268,6 +268,7 @@ To build, just run:
 ```
 $ git clone https://github.com/fltk-rs/fltk-rs
 $ cd fltk-rs
+$ git submodule update --init --recursive
 $ cargo build
 ```
 

--- a/examples
+++ b/examples
@@ -1,0 +1,1 @@
+fltk/examples/

--- a/fltk-sys/Cargo.toml
+++ b/fltk-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk-sys"
-version = "1.3.13"
+version = "1.3.14"
 authors = ["The fltk-rs Authors"]
 build = "build/main.rs"
 edition = "2018"

--- a/fltk-sys/build/link.rs
+++ b/fltk-sys/build/link.rs
@@ -135,6 +135,13 @@ pub fn link(target_os: &str, out_dir: &Path) {
                     println!("cargo:rustc-link-lib=dylib=wayland-cursor");
                     println!("cargo:rustc-link-lib=dylib=xkbcommon");
                     println!("cargo:rustc-link-lib=dylib=dbus-1");
+                    println!("cargo:rustc-link-lib=dylib=X11");
+                    println!("cargo:rustc-link-lib=dylib=Xext");
+                    println!("cargo:rustc-link-lib=dylib=Xinerama");
+                    println!("cargo:rustc-link-lib=dylib=Xcursor");
+                    println!("cargo:rustc-link-lib=dylib=Xrender");
+                    println!("cargo:rustc-link-lib=dylib=Xfixes");
+                    println!("cargo:rustc-link-lib=dylib=Xft");
                 } else {
                     println!("cargo:rustc-link-lib=dylib=X11");
                     println!("cargo:rustc-link-lib=dylib=Xext");

--- a/fltk-sys/build/source.rs
+++ b/fltk-sys/build/source.rs
@@ -58,12 +58,6 @@ pub fn build(manifest_dir: &Path, target_triple: &str, out_dir: &Path) {
     println!("cargo:rerun-if-changed=cfltk/src/cfl_vec.hpp");
     println!("cargo:rerun-if-changed=cfltk/fltk.patch");
 
-    Command::new("git")
-        .args(&["submodule", "update", "--init", "--recursive"])
-        .current_dir(manifest_dir)
-        .status()
-        .expect("Git is needed to retrieve the fltk source files!");
-
     if target_triple.contains("windows") {
         Command::new("git")
             .args(&["apply", "../fltk.patch"])
@@ -134,8 +128,10 @@ pub fn build(manifest_dir: &Path, target_triple: &str, out_dir: &Path) {
         if target_triple.contains("linux") && !target_triple.contains("android") {
             if cfg!(feature = "no-pango") {
                 dst.define("OPTION_USE_PANGO", "OFF");
+                // dst.define("FLTK_USE_CAIROXLIB", "OFF");
             } else {
                 dst.define("OPTION_USE_PANGO", "ON");
+                // dst.define("FLTK_USE_CAIROXLIB", "ON");
             }
         }
 
@@ -152,6 +148,7 @@ pub fn build(manifest_dir: &Path, target_triple: &str, out_dir: &Path) {
 
         if cfg!(feature = "use-wayland") {
             dst.define("OPTION_USE_WAYLAND", "ON");
+            dst.define("OPTION_ALLOW_GTK_PLUGIN", "OFF");
         }
 
         if cfg!(feature = "single-threaded") {

--- a/fltk-sys/src/fl.rs
+++ b/fltk-sys/src/fl.rs
@@ -684,3 +684,6 @@ extern "C" {
         cb: ::std::option::Option<unsafe extern "C" fn(arg1: *const ::std::os::raw::c_char)>,
     );
 }
+extern "C" {
+    pub fn Fl_disable_wayland();
+}

--- a/fltk/Cargo.toml
+++ b/fltk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk"
-version = "1.3.13"
+version = "1.3.14"
 authors = ["The fltk-rs Authors"]
 edition = "2018"
 description = "Rust bindings for the FLTK GUI library"
@@ -17,13 +17,13 @@ name = "fltk"
 path = "src/lib.rs"
 
 [dependencies]
-fltk-sys = { path = "../fltk-sys", version = "=1.3.13" }
+fltk-sys = { path = "../fltk-sys", version = "=1.3.14" }
 bitflags = "^1.3"
 paste = "1"
 crossbeam-channel = "0.5"
-ttf-parser = "0.15"
-raw-window-handle = { version = "^0.4", optional = true }
 once_cell = "1"
+ttf-parser = "0.15" # Enables returning a font name from load_font methods
+raw-window-handle = { version = "^0.5", optional = true } # Enables getting a raw window handle on supported platforms
 
 [features]
 default = []

--- a/fltk/src/app/font.rs
+++ b/fltk/src/app/font.rs
@@ -70,8 +70,8 @@ pub fn set_fonts(name: &str) -> i32 {
 
 /// Gets the name of a font through its index
 pub fn font_name(idx: usize) -> Option<String> {
-        let f = FONTS.lock().unwrap();
-        Some(f[idx].clone())
+    let f = FONTS.lock().unwrap();
+    Some(f[idx].clone())
 }
 
 /// Returns a list of available fonts to the application

--- a/fltk/src/app/init.rs
+++ b/fltk/src/app/init.rs
@@ -80,3 +80,9 @@ pub fn is_ui_thread() -> bool {
 pub fn is_initialized() -> bool {
     IS_INIT.load(Ordering::Relaxed)
 }
+
+/// Disables wayland when building with use-wayland.
+/// Needs to be called before showing the first window
+pub fn disable_wayland() {
+    unsafe { fl::Fl_disable_wayland() }
+}

--- a/fltk/src/app/mod.rs
+++ b/fltk/src/app/mod.rs
@@ -74,6 +74,7 @@ impl App {
 
     /**
         Loads a font from a path.
+        Requires enabling the ttf-parser feature to get a font name back from the method, otherwise you can pass the name directly to `enums::Font::by_name()`.
         On success, returns a String with the ttf Font Family name. The font's index is always 16.
         As such only one font can be loaded at a time.
         The font name can be used with [`Font::by_name`](`crate::enums::Font::by_name`), and index with [`Font::by_index`](`crate::enums::Font::by_index`).

--- a/fltk/src/enums.rs
+++ b/fltk/src/enums.rs
@@ -332,7 +332,8 @@ impl Font {
     }
 
     /**
-        Load font from file
+        Load font from file.
+        Requires enabling the ttf-parser feature to get a font name back from the method, otherwise you can pass the name directly to `enums::Font::set_font`.
         ```rust,no_run
         use fltk::enums::Font;
         let font = Font::load_font("font.ttf").unwrap();

--- a/fltk/src/macros/window.rs
+++ b/fltk/src/macros/window.rs
@@ -8,7 +8,7 @@ macro_rules! impl_window_ext {
             fn raw_window_handle(&self) -> RawWindowHandle {
                 #[cfg(target_os = "windows")]
                 {
-                    let mut handle = Win32Handle::empty();
+                    let mut handle = Win32WindowHandle::empty();
                     handle.hwnd = self.raw_handle();
                     handle.hinstance = $crate::app::display();
                     return RawWindowHandle::Win32(handle);
@@ -21,7 +21,7 @@ macro_rules! impl_window_ext {
                         pub fn cfltk_getContentView(xid: *mut raw::c_void) -> *mut raw::c_void;
                     }
                     let cv = unsafe { cfltk_getContentView(raw) };
-                    let mut handle = AppKitHandle::empty();
+                    let mut handle = AppKitWindowHandle::empty();
                     handle.ns_window = raw;
                     handle.ns_view = cv as _;
                     return RawWindowHandle::AppKit(handle);
@@ -29,7 +29,7 @@ macro_rules! impl_window_ext {
 
                 #[cfg(target_os = "android")]
                 {
-                    let mut handle = AndroidNdkHandle::empty();
+                    let mut handle = AndroidNdkWindowHandle::empty();
                     handle.a_native_window = self.raw_handle();
                     return RawWindowHandle::AndroidNdk(handle);
                 }
@@ -44,18 +44,16 @@ macro_rules! impl_window_ext {
                 {
                     #[cfg(not(feature = "use-wayland"))]
                     {
-                        let mut handle = XlibHandle::empty();
+                        let mut handle = XlibWindowHandle::empty();
                         handle.window = self.raw_handle();
-                        handle.display = $crate::app::display();
                         return RawWindowHandle::Xlib(handle);
                     }
 
 
                     #[cfg(feature = "use-wayland")]
                     {
-                        let mut handle = WaylandHandle::empty();
+                        let mut handle = WaylandWindowHandle::empty();
                         handle.surface = self.raw_handle();
-                        handle.display = $crate::app::display();
                         return RawWindowHandle::Wayland(handle);
                     }
                 }

--- a/fltk/src/text.rs
+++ b/fltk/src/text.rs
@@ -33,9 +33,9 @@ pub struct TextBuffer {
     refcount: AtomicUsize,
 }
 
-impl TextBuffer {
+impl std::default::Default for TextBuffer {
     /// Initialized a default text buffer
-    pub fn default() -> TextBuffer {
+    fn default() -> TextBuffer {
         unsafe {
             let text_buffer = Fl_Text_Buffer_new();
             assert!(!text_buffer.is_null());
@@ -45,7 +45,9 @@ impl TextBuffer {
             }
         }
     }
+}
 
+impl TextBuffer {
     /// Deletes the `TextBuffer`
     /// # Safety
     /// The buffer shouldn't be deleted while the Display widget still needs it


### PR DESCRIPTION
* add soft link to examples in root dir

* Update text.rs (#1275)

impl std::default::Default for TextBuffer

* avoid calling git submodule update in build script

* fix check

* make ttf-parser optional

* fix warning

* update docs

* update FLTK

* fix linking of hybrid wayland platform

* fix build

* pull fltk fixes

* update fltk

* update raw-window-handle to 0.5

* add disable_wayland

* fix build

* update fltk

* update readme

* update build script

* pull upstream fixes

* pull fltk

* update 1.3.14

Co-authored-by: Console <66591395+ConsoleC137@users.noreply.github.com>

# Description

Please include a summary of the change and whether it fixes an issue/bug. 
