### PR TITLE
fix for a segfault

### DIFF
--- a/fltk/src/macros/menu.rs
+++ b/fltk/src/macros/menu.rs
@@ -297,6 +297,9 @@ macro_rules! impl_menu_ext {
 
                 fn text(&self, idx: i32) -> Option<String> {
                     assert!(!self.was_deleted());
+                    if idx >= self.size() || idx < 0 {
+                        return None;
+                    }
                     unsafe {
                         let text = [<$flname _text>](self.inner, idx as i32);
                         if text.is_null() {


### PR DESCRIPTION
# Description

I added a fix to a segfault that is happening when calling .text() on an empty menu.
