### PR TITLE
Update group.rs (Adding ColorChooser::set_tuple_rgb)

### DIFF
--- a/fltk/src/group.rs
+++ b/fltk/src/group.rs
@@ -433,6 +433,24 @@ impl ColorChooser {
             }
         }
     }
+    
+    /// Set the base color of the ColorChooser. Returns an error on failure to change the color (wrong input)
+    pub fn set_tuple_rgb(&mut self, (r, g, b): (u8, u8, u8)) -> Result<(), FltkError> {
+        assert!(!self.was_deleted());
+        unsafe {
+            let ret = Fl_Color_Chooser_set_rgb(
+                self.inner,
+                r as f64 / 255.0,
+                g as f64 / 255.0,
+                b as f64 / 255.0,
+            );
+            if ret == 1 {
+                Ok(())
+            } else {
+                Err(FltkError::Internal(FltkErrorKind::FailedOperation))
+            }
+        }
+    }
 }
 
 crate::macros::widget::impl_widget_type!(FlexType);


### PR DESCRIPTION
Adding `set_tuple_rgb` for ColorChooser. Destroying a tuple is inconvenient, it is much easier to pass the tuple to the function completely.

1) set_rgb
```
let (r, g, b) = Color::from_hex_str("#c0c0c0").unwrap().to_rgb();
cc.set_rgb(r, g, b).unwrap();
```

2) set_tuple_rgb

`cc.set_tuple_rgb(Color::from_hex_str("#c0c0c0").unwrap().to_rgb()).unwrap();`
