### PR TITLE
Updated dock_win.handle()

### DIFF
--- a/fltk/examples/shapedwindow_taskbar.rs
+++ b/fltk/examples/shapedwindow_taskbar.rs
@@ -84,16 +84,7 @@ fn main() {
         let mut win = win.clone();
         move |wself, event| match (event) {
             enums::Event::Focus => {
-                let win_shape = prep_shape(win.w(), win.h());
-
-                win.hide();
                 win.show();
-
-                /* 
-                   After hiding and showing, the main window will not retain it's previous shape
-                   Retain it's original shape by setting it's shape again
-                */
-                win.set_shape(Some(win_shape)); 
 
                 true
             },

--- a/fltk/examples/shapedwindow_taskbar.rs
+++ b/fltk/examples/shapedwindow_taskbar.rs
@@ -88,6 +88,11 @@ fn main() {
 
                 true
             },
+            enums::Event::Hide => {
+               win.hide();
+               
+               true
+            },
             enums::Event::Close => {
                 app.quit();
 

--- a/fltk/examples/shapedwindow_taskbar.rs
+++ b/fltk/examples/shapedwindow_taskbar.rs
@@ -84,7 +84,10 @@ fn main() {
         let mut win = win.clone();
         move |wself, event| match (event) {
             enums::Event::Focus => {
+                let win_shape = prep_shape(win.w(), win.h());
+            
                 win.show();
+                win.set_shape(Some(win_shape));
 
                 true
             },


### PR DESCRIPTION
# Description

.hide()
.set_shape(Some(win_shape))

Resetting the window using this method caused issues with ScrollGroup's
Children disappearing on Window re-open, after second re-open it crashes the application

Removing these two lines fixed the underlying issue.

Also added hiding of the main window when taskbar item is unfocused from being pressed.