### PR TITLE
SimpleTerminal::append2 should not allocate a CString

### DIFF
--- a/fltk/src/text.rs
+++ b/fltk/src/text.rs
@@ -1140,8 +1140,7 @@ impl SimpleTerminal {
     pub fn append2(&mut self, s: &[u8]) {
         assert!(!self.was_deleted());
         assert!(self.buffer().is_some());
-        let s = CString::new(s).unwrap();
-        unsafe { Fl_Simple_Terminal_append2(self.inner, s.into_raw(), -1) }
+        unsafe { Fl_Simple_Terminal_append2(self.inner, s.as_ptr() as _, s.len() as _) }
     }
 
     /// Sets the text of the terminal buffer


### PR DESCRIPTION
Given Fl_Simple_Terminal_append2 can take a length argument, we can just pass the slice and length directly to FLTK.