### PR TITLE
enable feature `doc_auto_cfg` for docs.rs

### DIFF
--- a/fltk-sys/Cargo.toml
+++ b/fltk-sys/Cargo.toml
@@ -40,3 +40,7 @@ use-wayland = []
 static-msvcrt = []
 cairoext = []
 fltk-config = ["cc"]
+
+[package.metadata.docs.rs]
+features = ["enable-glwindow"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/fltk-sys/src/lib.rs
+++ b/fltk-sys/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, allow(unused_attributes))]
 #![doc = include_str!("../README.md")]
 #![allow(non_camel_case_types)]
 #![allow(dead_code)]

--- a/fltk/Cargo.toml
+++ b/fltk/Cargo.toml
@@ -67,6 +67,7 @@ fltk-config = ["fltk-sys/fltk-config"]
 
 [package.metadata.docs.rs]
 features = ["enable-glwindow"]
+rustdoc-args = ["--cfg", "docsrs"]
 
 [[test]]
 name = "app_handle"

--- a/fltk/src/lib.rs
+++ b/fltk/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, allow(unused_attributes))]
 #![doc = include_str!("../README.md")]
 #![allow(non_upper_case_globals)]
 #![allow(clippy::needless_doctest_main)]


### PR DESCRIPTION
# Description
enable feature `doc_auto_cfg` for docs.rs

Enhance docs in docs.rs by adding target/feature mark to item.  
Test it local:
```shell
RUSTFLAGS="--cfg=docsrs" RUSTDOCFLAGS="--cfg=docsrs" cargo +nightly doc --open
```

