### PR TITLE
editor, editor2 examples: Add accelerators

### DIFF
--- a/fltk/examples/editor.rs
+++ b/fltk/examples/editor.rs
@@ -23,56 +23,56 @@ impl State {
 
 fn init_menu(m: &mut menu::SysMenuBar) {
     m.add(
-        "&File/New...\t",
+        "&File/&New...\t",
         Shortcut::Ctrl | 'n',
         menu::MenuFlag::Normal,
         menu_cb,
     );
     m.add(
-        "&File/Open...\t",
+        "&File/&Open...\t",
         Shortcut::Ctrl | 'o',
         menu::MenuFlag::Normal,
         menu_cb,
     );
     m.add(
-        "&File/Save\t",
+        "&File/&Save\t",
         Shortcut::Ctrl | 's',
         menu::MenuFlag::Normal,
         menu_cb,
     );
     m.add(
-        "&File/Save as...\t",
+        "&File/Save &as...\t",
         Shortcut::Ctrl | 'w',
         menu::MenuFlag::MenuDivider,
         menu_cb,
     );
     let idx = m.add(
-        "&File/Quit\t",
+        "&File/&Quit\t",
         Shortcut::Ctrl | 'q',
         menu::MenuFlag::Normal,
         menu_cb,
     );
     m.at(idx).unwrap().set_label_color(Color::Red);
     m.add(
-        "&Edit/Cut\t",
+        "&Edit/Cu&t\t",
         Shortcut::Ctrl | 'x',
         menu::MenuFlag::Normal,
         menu_cb,
     );
     m.add(
-        "&Edit/Copy\t",
+        "&Edit/&Copy\t",
         Shortcut::Ctrl | 'c',
         menu::MenuFlag::Normal,
         menu_cb,
     );
     m.add(
-        "&Edit/Paste\t",
+        "&Edit/&Paste\t",
         Shortcut::Ctrl | 'v',
         menu::MenuFlag::Normal,
         menu_cb,
     );
     m.add(
-        "&Help/About\t",
+        "&Help/&About\t",
         Shortcut::None,
         menu::MenuFlag::Normal,
         menu_cb,
@@ -121,8 +121,8 @@ fn quit_cb() {
         } else {
             let c = dialog::choice2_default(
                 "Are you sure you want to exit without saving?",
-                "Yes",
-                "No",
+                "&Yes",
+                "&No",
                 "",
             );
             if c == Some(0) {
@@ -196,13 +196,13 @@ fn menu_cb(m: &mut impl MenuExt) {
     if let Ok(mpath) = m.item_pathname(None) {
         let ed: text::TextEditor = app::widget_from_id("ed").unwrap();
         match mpath.as_str() {
-            "&File/New...\t" => {
+            "&File/&New...\t" => {
                 STATE.with(|s| {
                     if !s.buf.text().is_empty() {
                         let c = dialog::choice2_default(
                             "Are you sure you want to clear the buffer?",
-                            "Yes",
-                            "No",
+                            "&Yes",
+                            "&No",
                             "",
                         );
                         if c == Some(0) {
@@ -212,7 +212,7 @@ fn menu_cb(m: &mut impl MenuExt) {
                     }
                 });
             }
-            "&File/Open...\t" => {
+            "&File/&Open...\t" => {
                 if let Some(c) = nfc_get_file(dialog::NativeFileChooserType::BrowseFile) {
                     if let Ok(text) = std::fs::read_to_string(&c) {
                         STATE.with(move |s| {
@@ -223,14 +223,14 @@ fn menu_cb(m: &mut impl MenuExt) {
                     }
                 }
             }
-            "&File/Save\t" => {
+            "&File/&Save\t" => {
                 STATE.with(|s| {
                     if !s.saved && s.current_file.exists() {
                         std::fs::write(&s.current_file, s.buf.text()).ok();
                     }
                 });
             }
-            "&File/Save as...\t" => {
+            "&File/Save &as...\t" => {
                 if let Some(c) = nfc_get_file(dialog::NativeFileChooserType::BrowseSaveFile) {
                     STATE.with(move |s| {
                         std::fs::write(&c, s.buf.text()).ok();
@@ -239,11 +239,11 @@ fn menu_cb(m: &mut impl MenuExt) {
                     });
                 }
             }
-            "&File/Quit\t" => quit_cb(),
-            "&Edit/Cut\t" => ed.cut(),
-            "&Edit/Copy\t" => ed.copy(),
-            "&Edit/Paste\t" => ed.paste(),
-            "&Help/About\t" => {
+            "&File/&Quit\t" => quit_cb(),
+            "&Edit/Cu&t\t" => ed.cut(),
+            "&Edit/&Copy\t" => ed.copy(),
+            "&Edit/&Paste\t" => ed.paste(),
+            "&Help/&About\t" => {
                 dialog::message_default("A minimal text editor written using fltk-rs!")
             }
             _ => unreachable!(),

--- a/fltk/examples/editor2.rs
+++ b/fltk/examples/editor2.rs
@@ -107,7 +107,7 @@ impl MyMenu {
         let mut menu = menu::SysMenuBar::default().with_size(800, 35);
         menu.set_frame(FrameType::FlatBox);
         menu.add_emit(
-            "&File/New...\t",
+            "&File/&New...\t",
             Shortcut::Ctrl | 'n',
             menu::MenuFlag::Normal,
             *s,
@@ -115,7 +115,7 @@ impl MyMenu {
         );
 
         menu.add_emit(
-            "&File/Open...\t",
+            "&File/&Open...\t",
             Shortcut::Ctrl | 'o',
             menu::MenuFlag::Normal,
             *s,
@@ -123,7 +123,7 @@ impl MyMenu {
         );
 
         menu.add_emit(
-            "&File/Save\t",
+            "&File/&Save\t",
             Shortcut::Ctrl | 's',
             menu::MenuFlag::Normal,
             *s,
@@ -131,7 +131,7 @@ impl MyMenu {
         );
 
         menu.add_emit(
-            "&File/Save as...\t",
+            "&File/Save &as...\t",
             Shortcut::Ctrl | 'w',
             menu::MenuFlag::Normal,
             *s,
@@ -139,7 +139,7 @@ impl MyMenu {
         );
 
         menu.add_emit(
-            "&File/Print...\t",
+            "&File/&Print...\t",
             Shortcut::Ctrl | 'p',
             menu::MenuFlag::MenuDivider,
             *s,
@@ -147,7 +147,7 @@ impl MyMenu {
         );
 
         menu.add_emit(
-            "&File/Quit\t",
+            "&File/&Quit\t",
             Shortcut::Ctrl | 'q',
             menu::MenuFlag::Normal,
             *s,
@@ -155,7 +155,7 @@ impl MyMenu {
         );
 
         menu.add_emit(
-            "&Edit/Cut\t",
+            "&Edit/Cu&t\t",
             Shortcut::Ctrl | 'x',
             menu::MenuFlag::Normal,
             *s,
@@ -163,7 +163,7 @@ impl MyMenu {
         );
 
         menu.add_emit(
-            "&Edit/Copy\t",
+            "&Edit/&Copy\t",
             Shortcut::Ctrl | 'c',
             menu::MenuFlag::Normal,
             *s,
@@ -171,7 +171,7 @@ impl MyMenu {
         );
 
         menu.add_emit(
-            "&Edit/Paste\t",
+            "&Edit/&Paste\t",
             Shortcut::Ctrl | 'v',
             menu::MenuFlag::Normal,
             *s,
@@ -179,7 +179,7 @@ impl MyMenu {
         );
 
         menu.add_emit(
-            "&Help/About\t",
+            "&Help/&About\t",
             Shortcut::None,
             menu::MenuFlag::Normal,
             *s,
@@ -215,7 +215,7 @@ impl MyApp {
             .with_label("RustyEd");
         let menu = MyMenu::new(&s);
         let modified = false;
-        menu.menu.find_item("&File/Save\t").unwrap().deactivate();
+        menu.menu.find_item("&File/&Save\t").unwrap().deactivate();
         let mut editor = MyEditor::new(buf.clone());
         editor.emit(s, Message::Changed);
         main_win.make_resizable(true);
@@ -328,12 +328,12 @@ impl MyApp {
                 self.modified = false;
                 self.menu
                     .menu
-                    .find_item("&File/Save\t")
+                    .find_item("&File/&Save\t")
                     .unwrap()
                     .deactivate();
                 self.menu
                     .menu
-                    .find_item("&File/Quit\t")
+                    .find_item("&File/&Quit\t")
                     .unwrap()
                     .set_label_color(Color::Black);
                 let name = match &self.filename {
@@ -355,12 +355,12 @@ impl MyApp {
             self.modified = false;
             self.menu
                 .menu
-                .find_item("&File/Save\t")
+                .find_item("&File/&Save\t")
                 .unwrap()
                 .deactivate();
             self.menu
                 .menu
-                .find_item("&File/Quit\t")
+                .find_item("&File/&Quit\t")
                 .unwrap()
                 .set_label_color(Color::Black);
             self.filename = Some(c);
@@ -380,8 +380,8 @@ impl MyApp {
                     Changed => {
                         if !self.modified {
                             self.modified = true;
-                            self.menu.menu.find_item("&File/Save\t").unwrap().activate();
-                            self.menu.menu.find_item("&File/Quit\t").unwrap().set_label_color(Color::Red);
+                            self.menu.menu.find_item("&File/&Save\t").unwrap().activate();
+                            self.menu.menu.find_item("&File/&Quit\t").unwrap().set_label_color(Color::Red);
                             let name = match &self.filename {
                                 Some(f) => f.to_string_lossy().to_string(),
                                 None => "(Untitled)".to_string(),
@@ -391,7 +391,7 @@ impl MyApp {
                     }
                     New => {
                         if self.buf.text() != "" {
-                            let clear = if let Some(x) = dialog::choice2(center().0 - 200, center().1 - 100, "File unsaved, Do you wish to continue?", "Yes", "No!", "") {
+                            let clear = if let Some(x) = dialog::choice2(center().0 - 200, center().1 - 100, "File unsaved, Do you wish to continue?", "&Yes", "&No!", "") {
                                 x == 0
                             } else {
                                 false
@@ -434,7 +434,7 @@ impl MyApp {
                     Quit => {
                         if self.modified {
                             match dialog::choice2(center().0 - 200, center().1 - 100,
-                                "Would you like to save your work?", "Yes", "No", "") {
+                                "Would you like to save your work?", "&Yes", "&No", "") {
                                 Some(0) => {
                                     if self.save_file().unwrap() {
                                         self.app.quit();


### PR DESCRIPTION
The editor examples were not taking full advantage of accelerators: menus had accelerators, but their items didn't, making them much less useful.

They're easy enough to add, and I think it's important that new developers see them in the examples and know that they work and how to use them, so that they also use them... because if there is something I could use less of, is GUI applications being needlessly awkward to use with a keyboard.