### PR TITLE
Fix set_on_top for macos and add windows implementation

### DIFF
--- a/fltk/src/window.rs
+++ b/fltk/src/window.rs
@@ -256,6 +256,7 @@ impl SingleWindow {
 
     /// Set the window to be on top of other windows. 
     /// Must only be called after the window has been shown.
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
     pub fn set_on_top(&mut self) {
         assert!(!self.raw_handle().is_null());
         #[cfg(target_os = "macos")]
@@ -538,6 +539,7 @@ impl DoubleWindow {
 
     /// Set the window to be on top of other windows. 
     /// Must only be called after the window has been shown.
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
     pub fn set_on_top(&mut self) {
         assert!(!self.raw_handle().is_null());
         #[cfg(target_os = "macos")]

--- a/fltk/src/window.rs
+++ b/fltk/src/window.rs
@@ -210,7 +210,7 @@ impl SingleWindow {
 
     /// Returns the pixels per unit/point
     pub fn pixels_per_unit(&self) -> f32 {
-        #[allow(unused_mut)]
+        #[allow(unused_mut)] 
         let mut factor = 1.0;
         #[cfg(target_os = "macos")]
         {
@@ -254,16 +254,29 @@ impl SingleWindow {
         unsafe { Fl_Single_Window_set_default_xclass(s.as_ptr()) }
     }
 
-    /// Set the borderless window to be on top of the macos system menu bar
-    pub fn set_on_top(&self) {
+    /// Set the window to be on top of other windows. 
+    /// Must only be called after the window has been shown.
+    pub fn set_on_top(&mut self) {
+        assert!(!self.raw_handle().is_null());
         #[cfg(target_os = "macos")]
         {
             extern "C" {
                 pub fn cfltk_setOnTop(handle: *mut raw::c_void);
             }
-            assert!(self.border());
             unsafe {
                 cfltk_setOnTop(self.raw_handle());
+            }
+        }
+        #[cfg(target_os = "windows")]
+        {
+            extern "system" {
+                fn SetWindowPos(hwnd: *mut raw::c_void, insert_after: isize, x: i32, y: i32, cx: i32, cy: i32, flags: u32) -> bool;
+            }
+            const TOP_MOST: isize = -1;
+            const SWP_NOSIZE: u32 = 1;
+            const SWP_NOMOVE: u32 = 2;
+            unsafe {
+                SetWindowPos(self.raw_handle(), TOP_MOST, 0, 0, 0, 0, SWP_NOSIZE | SWP_NOMOVE);
             }
         }
     }
@@ -476,7 +489,7 @@ impl DoubleWindow {
                 }
                 cfltk_winHide(self.raw_handle());
             }
-            #[cfg(not(any(target_os = "macos", target_os = "android", target_os = "windows",)))]
+            #[cfg(not(any(target_os = "macos", target_os = "android", target_os = "windows")))]
             {
                 #[cfg(not(feature = "use-wayland"))]
                 {
@@ -523,15 +536,30 @@ impl DoubleWindow {
         unsafe { Fl_Double_Window_set_default_xclass(s.as_ptr()) }
     }
 
-    #[cfg(target_os = "macos")]
-    /// Set the borderless window to be on top of the macos system menu bar
+    /// Set the window to be on top of other windows. 
+    /// Must only be called after the window has been shown.
     pub fn set_on_top(&mut self) {
-        assert!(!self.border());
-        extern "C" {
-            pub fn cfltk_setOnTop(handle: *mut raw::c_void);
+        assert!(!self.raw_handle().is_null());
+        #[cfg(target_os = "macos")]
+        {
+            extern "C" {
+                pub fn cfltk_setOnTop(handle: *mut raw::c_void);
+            }
+            unsafe {
+                cfltk_setOnTop(self.raw_handle());
+            }
         }
-        unsafe {
-            cfltk_setOnTop(self.raw_handle());
+        #[cfg(target_os = "windows")]
+        {
+            extern "system" {
+                fn SetWindowPos(hwnd: *mut raw::c_void, insert_after: isize, x: i32, y: i32, cx: i32, cy: i32, flags: u32) -> bool;
+            }
+            const TOP_MOST: isize = -1;
+            const SWP_NOSIZE: u32 = 1;
+            const SWP_NOMOVE: u32 = 2;
+            unsafe {
+                SetWindowPos(self.raw_handle(), TOP_MOST, 0, 0, 0, 0, SWP_NOSIZE | SWP_NOMOVE);
+            }
         }
     }
 


### PR DESCRIPTION
Closes #1573

I have tested that `cfltk_setOnTop` works correctly regardless of whether the window is borderless or not. 

The windows implementation is simple. Technically, we could extend the implementation to support setting this before the window has opened but this feels good enough.

I did also try a Linux/X11 implementation but I didn't get it working. It would be much easier if the bindings (like xlib-rs or windows-rs) were available instead of inline externs.

Here's my (not working) X11 attempt in case you'd like to give it a go:

```rust
#[cfg(not(any(target_os = "macos", target_os = "android", target_os = "windows", feature = "use-wayland")))]
{
    assert!(self.raw_handle() != 0);
    use std::os::raw::{c_char, c_int, c_ulong};
    use crate::app::Display;

    extern "C" {
        fn XInternAtom(display: Display, atom_name: *const c_char, only_if_exists: c_int) -> c_ulong;
        fn XSendEvent(
            display: Display, 
            w: c_ulong, 
            propagate: c_int, 
            event_mask: c_ulong, 
            event_send: *const XClientMessageEvent
        ) -> c_int;
        fn XFlush(display: Display);
        fn XDefaultScreen(display: Display) -> c_int;
        fn XRootWindow(display: Display, screen_number: c_int) -> c_ulong;
    }
    
    #[repr(C)]
    struct XClientMessageEvent {
        type_: c_int,
        serial: c_ulong,
        send_event: c_int,
        display: Display,
        window: c_ulong,
        message_type: c_ulong,
        format: c_int,
        data: [c_ulong; 5],
    }
    
    // Constants from X11
    const False: c_int = 0;
    const True: c_int = 1;
    const ClientMessage: c_int = 33;
    const SubstructureRedirectMask: c_ulong = 0x00000001;
    const SubstructureNotifyMask: c_ulong = 0x00000002;

    unsafe {
        let display = crate::app::display();
        let net_wm_state = XInternAtom(display, "_NET_WM_STATE\0".as_ptr() as *const c_char, False);
        let net_wm_state_above = XInternAtom(display, "_NET_WM_STATE_ABOVE\0".as_ptr() as *const c_char, False);

        let event = XClientMessageEvent {
            type_: ClientMessage,
            serial: 0,
            send_event: True,
            display,
            window: self.raw_handle(),
            message_type: net_wm_state,
            format: 32,
            data: [
                1, // _NET_WM_STATE_ADD
                net_wm_state_above as c_ulong,
                0, // no second property
                0, // source indication (2 for pager)
                0  // unused
            ],
        };

        let screen_number = XDefaultScreen(display);
        let root = XRootWindow(display, screen_number);

        XSendEvent(display, root, False, SubstructureRedirectMask | SubstructureNotifyMask, &event as *const _ as *const XClientMessageEvent);
        XFlush(display);
    }
}
```

And this post for reference: https://stackoverflow.com/questions/4345224/x11-xlib-window-always-on-top